### PR TITLE
Workaround/bugfix for correct initialization of Thompson MP

### DIFF
--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -410,23 +410,22 @@ MODULE module_mp_thompson
 !! lookup tables in Thomspson scheme.
 !>\section gen_thompson_init thompson_init General Algorithm
 !> @{
-      SUBROUTINE thompson_init(nwfa2d, nifa2d, nwfa, nifa,  &
-                          ids, ide, jds, jde, kds, kde,     &
-                          ims, ime, jms, jme, kms, kme,     &
-                          its, ite, jts, jte, kts, kte,     &
-                          mpicomm, mpirank, mpiroot,        &
-                          threads, errmsg, errflg)
+      SUBROUTINE thompson_init(nwfa2d, nifa2d, nwfa, nifa, &
+                               mpicomm, mpirank, mpiroot,  &
+                               threads, errmsg, errflg)
 
       IMPLICIT NONE
 
-      INTEGER, INTENT(IN):: ids,ide, jds,jde, kds,kde, &
-                            ims,ime, jms,jme, kms,kme, &
-                            its,ite, jts,jte, kts,kte
-
 !..OPTIONAL variables that control application of aerosol-aware scheme
 
-      REAL, DIMENSION(ims:ime,kms:kme,jms:jme), OPTIONAL, INTENT(IN) :: nwfa, nifa
-      REAL, DIMENSION(ims:ime,jms:jme),         OPTIONAL, INTENT(IN) :: nwfa2d, nifa2d
+#if 0
+      REAL, DIMENSION(:,:,:), OPTIONAL, INTENT(IN) :: nwfa, nifa
+      REAL, DIMENSION(:,:),   OPTIONAL, INTENT(IN) :: nwfa2d, nifa2d
+#else
+! DH* 20200208 - change dimensions for nasty init hack
+      REAL, DIMENSION(:,:), OPTIONAL, INTENT(IN) :: nwfa, nifa
+      REAL, DIMENSION(:),   OPTIONAL, INTENT(IN) :: nwfa2d, nifa2d
+#endif
       INTEGER, INTENT(IN) :: mpicomm, mpirank, mpiroot
       INTEGER, INTENT(IN) :: threads
       CHARACTER(len=*), INTENT(INOUT) :: errmsg

--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -23,10 +23,17 @@ module mp_thompson
 
    contains
 
+! DH* Note. The following is a nasty modification of the mp_thompson_init
+! routine to account for the fact that the initialization of the physics
+! must run over all blocks concurrently. In order to pass in the arguments
+! as individual Fortran arrays as before, we need to remove the dynamic
+! build first and add logic to detect that an array ...
+
 !> This subroutine is a wrapper around the actual thompson_init().
 !! \section arg_table_mp_thompson_init Argument Table
 !! \htmlinclude mp_thompson_init.html
 !!
+#if 0
       subroutine mp_thompson_init(ncol, nlev, con_g, con_rd, restart,   &
                                   imp_physics, imp_physics_thompson,    &
                                   spechum, qc, qr, qi, qs, qg, ni, nr,  &
@@ -81,10 +88,6 @@ module mp_thompson
          character(len=*),          intent(  out) :: errmsg
          integer,                   intent(  out) :: errflg
 
-         ! Local variables: dimensions used in thompson_init
-         integer               :: ids,ide, jds,jde, kds,kde, &
-                                  ims,ime, jms,jme, kms,kme, &
-                                  its,ite, jts,jte, kts,kte
          ! Hydrometeors
          real(kind_phys) :: qv_mp(1:ncol,1:nlev) !< kg kg-1 (dry mixing ratio)
          real(kind_phys) :: qc_mp(1:ncol,1:nlev) !< kg kg-1 (dry mixing ratio)
@@ -102,6 +105,91 @@ module mp_thompson
          !
          real (kind=kind_phys) :: h_01, airmass, niIN3, niCCN3
          integer :: i, k
+#else
+      subroutine mp_thompson_init(Data, ntqv, ntcw, ntrw, ntiw, ntsw, ntgl,   &
+                                  ntinc, ntrnc, ntlnc, ntwa, ntia, nleffr,    &
+                                  nieffr, nseffr, con_g, con_rd,              &
+                                  restart, imp_physics, imp_physics_thompson, &
+                                  is_aerosol_aware, mpicomm, mpirank, mpiroot,&
+                                  threads, errmsg, errflg)
+
+         use GFS_typedefs, only : GFS_data_type
+
+         implicit none
+
+         ! Interface variables
+         type(GFS_data_type),       intent(inout) :: Data(:)
+         integer,                   intent(in   ) :: ntqv
+         integer,                   intent(in   ) :: ntcw
+         integer,                   intent(in   ) :: ntrw
+         integer,                   intent(in   ) :: ntiw
+         integer,                   intent(in   ) :: ntsw
+         integer,                   intent(in   ) :: ntgl
+         integer,                   intent(in   ) :: ntinc
+         integer,                   intent(in   ) :: ntrnc
+         integer,                   intent(in   ) :: ntlnc
+         integer,                   intent(in   ) :: ntwa
+         integer,                   intent(in   ) :: ntia
+         integer,                   intent(in   ) :: nleffr
+         integer,                   intent(in   ) :: nieffr
+         integer,                   intent(in   ) :: nseffr
+         real(kind_phys),           intent(in   ) :: con_g, con_rd
+         logical,                   intent(in   ) :: restart
+         integer,                   intent(in   ) :: imp_physics
+         integer,                   intent(in   ) :: imp_physics_thompson
+         ! Aerosols
+         logical,                   intent(in   ) :: is_aerosol_aware
+         ! MPI information
+         integer,                   intent(in   ) :: mpicomm
+         integer,                   intent(in   ) :: mpirank
+         integer,                   intent(in   ) :: mpiroot
+         ! Threading/blocking information
+         integer,                   intent(in   ) :: threads
+         ! CCPP error handling
+         character(len=*),          intent(  out) :: errmsg
+         integer,                   intent(  out) :: errflg
+
+         ! Local variables/pointers
+
+         ! Hydrometeors
+         real(kind_phys), dimension(:,:), allocatable :: qv_mp !< kg kg-1 (dry mixing ratio)
+         real(kind_phys), dimension(:,:), allocatable :: qc_mp !< kg kg-1 (dry mixing ratio)
+         real(kind_phys), dimension(:,:), allocatable :: qr_mp !< kg kg-1 (dry mixing ratio)
+         real(kind_phys), dimension(:,:), allocatable :: qi_mp !< kg kg-1 (dry mixing ratio)
+         real(kind_phys), dimension(:,:), allocatable :: qs_mp !< kg kg-1 (dry mixing ratio)
+         real(kind_phys), dimension(:,:), allocatable :: qg_mp !< kg kg-1 (dry mixing ratio)
+         real(kind_phys), dimension(:,:), allocatable :: ni_mp !< kg-1
+         real(kind_phys), dimension(:,:), allocatable :: nr_mp !< kg-1
+         real(kind_phys), dimension(:,:), allocatable :: nc_mp !< kg-1
+         !
+         real(kind_phys), dimension(:,:), allocatable :: hgt   ! m
+         real(kind_phys), dimension(:,:), allocatable :: rho   ! kg m-3
+         real(kind_phys), dimension(:,:), allocatable :: orho  ! m3 kg-1
+         real(kind_phys), pointer :: spechum  (:,:)
+         real(kind_phys), pointer :: qc       (:,:)
+         real(kind_phys), pointer :: qr       (:,:)
+         real(kind_phys), pointer :: qi       (:,:)
+         real(kind_phys), pointer :: qs       (:,:)
+         real(kind_phys), pointer :: qg       (:,:)
+         real(kind_phys), pointer :: ni       (:,:)
+         real(kind_phys), pointer :: nr       (:,:)
+         real(kind_phys), pointer :: nc       (:,:)
+         real(kind_phys), pointer :: nwfa     (:,:)
+         real(kind_phys), pointer :: nifa     (:,:)
+         real(kind_phys), pointer :: nwfa2d   (:)
+         real(kind_phys), pointer :: nifa2d   (:)
+         real(kind_phys), pointer :: tgrs     (:,:)
+         real(kind_phys), pointer :: prsl     (:,:)
+         real(kind_phys), pointer :: phil     (:,:)
+         real(kind_phys), pointer :: area     (:)
+         real(kind_phys), pointer :: re_cloud (:,:)
+         real(kind_phys), pointer :: re_ice   (:,:)
+         real(kind_phys), pointer :: re_snow  (:,:)
+
+         !
+         real (kind=kind_phys) :: h_01, airmass, niIN3, niCCN3
+         integer :: i, k, blkno, nblocks, ncol, nlev
+#endif
 
          ! Initialize the CCPP error handling variables
          errmsg = ''
@@ -124,153 +212,158 @@ module mp_thompson
             return
          end if
 
-         if (is_aerosol_aware     .and. &
-             (.not.present(nc)     .or. &
-              .not.present(nwfa2d) .or. &
-              .not.present(nifa2d) .or. &
-              .not.present(nwfa)   .or. &
-              .not.present(nifa)        )) then
-             write(errmsg,fmt='(*(a))') 'Logic error in mp_thompson_init:',                         &
-                                        ' aerosol-aware microphysics require all of the following', &
-                                        ' optional arguments: nc, nwfa2d, nifa2d, nwfa, nifa'
-             errflg = 1
-             return
-          end if
+         nblocks = size(Data)
+         block_loop: do blkno=1,nblocks
 
-         ! Set internal dimensions
-         ids = 1
-         ims = 1
-         its = 1
-         ide = ncol
-         ime = ncol
-         ite = ncol
-         jds = 1
-         jms = 1
-         jts = 1
-         jde = 1
-         jme = 1
-         jte = 1
-         kds = 1
-         kms = 1
-         kts = 1
-         kde = nlev
-         kme = nlev
-         kte = nlev
+         !  associate_arrays: associate(                   &
+             spechum  => Data(blkno)%Statein%qgrs(:,:,ntqv) !,&
+             qc       => Data(blkno)%Statein%qgrs(:,:,ntcw) !,&
+             qr       => Data(blkno)%Statein%qgrs(:,:,ntrw) !,&
+             qi       => Data(blkno)%Statein%qgrs(:,:,ntiw) !,&
+             qs       => Data(blkno)%Statein%qgrs(:,:,ntsw) !,&
+             qg       => Data(blkno)%Statein%qgrs(:,:,ntgl) !,&
+             ni       => Data(blkno)%Statein%qgrs(:,:,ntinc)!,&
+             nr       => Data(blkno)%Statein%qgrs(:,:,ntrnc)!,&
+             nc       => Data(blkno)%Statein%qgrs(:,:,ntlnc)!,&
+             nwfa     => Data(blkno)%Statein%qgrs(:,:,ntwa) !,&
+             nifa     => Data(blkno)%Statein%qgrs(:,:,ntia) !,&
+             nwfa2d   => Data(blkno)%Coupling%nwfa2d        !,&
+             nifa2d   => Data(blkno)%Coupling%nifa2d        !,&
+             tgrs     => Data(blkno)%Statein%tgrs           !,&
+             prsl     => Data(blkno)%Statein%prsl           !,&
+             phil     => Data(blkno)%Statein%phil           !,&
+             area     => Data(blkno)%Grid%area              !,&
+             re_cloud => Data(blkno)%Tbd%phy_f3d(:,:,nleffr)!,&
+             re_ice   => Data(blkno)%Tbd%phy_f3d(:,:,nieffr)!,&
+             re_snow  => Data(blkno)%Tbd%phy_f3d(:,:,nseffr)! )
 
-         ! Call Thompson init
-         if (is_aerosol_aware) then
-            call thompson_init(nwfa2d=nwfa2d, nifa2d=nifa2d, nwfa=nwfa, nifa=nifa,   &
-                               ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde, &
-                               ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme, &
-                               its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte, &
-                               mpicomm=mpicomm, mpirank=mpirank, mpiroot=mpiroot,    &
-                               threads=threads, errmsg=errmsg, errflg=errflg)
-            if (errflg /= 0) return
-         else
-            call thompson_init(ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde, &
-                               ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme, &
-                               its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte, &
-                               mpicomm=mpicomm, mpirank=mpirank, mpiroot=mpiroot,    &
-                               threads=threads, errmsg=errmsg, errflg=errflg)
-            if (errflg /= 0) return
-         end if
+             ncol = size(spechum(:,1))
+             nlev = size(spechum(1,:))
+             allocate(qv_mp(ncol,nlev))
+             allocate(qc_mp(ncol,nlev))
+             allocate(qr_mp(ncol,nlev))
+             allocate(qi_mp(ncol,nlev))
+             allocate(qs_mp(ncol,nlev))
+             allocate(qg_mp(ncol,nlev))
+             allocate(ni_mp(ncol,nlev))
+             allocate(nr_mp(ncol,nlev))
+             allocate(nc_mp(ncol,nlev))
+             allocate(hgt  (ncol,nlev))
+             allocate(rho  (ncol,nlev))
+             allocate(orho (ncol,nlev))
 
-         ! For restart runs, the init is done here
-         if (restart) then
-             is_initialized = .true.
-             return
-         end if
+             only_for_first_block: if (blkno==1) then
 
-         ! Fix initial values of hydrometeors
-         where(spechum<0) spechum = 0.0
-         where(qc<0)      qc = 0.0
-         where(qr<0)      qr = 0.0
-         where(qi<0)      qi = 0.0
-         where(qs<0)      qs = 0.0
-         where(qg<0)      qg = 0.0
-         where(ni<0)      ni = 0.0
-         where(nr<0)      nr = 0.0
+               ! Call Thompson init
+               if (is_aerosol_aware) then
+                  call thompson_init(nwfa2d=nwfa2d, nifa2d=nifa2d, nwfa=nwfa, nifa=nifa,   &
+                                     mpicomm=mpicomm, mpirank=mpirank, mpiroot=mpiroot,    &
+                                     threads=threads, errmsg=errmsg, errflg=errflg)
+                  if (errflg /= 0) return
+               else
+                  call thompson_init(mpicomm=mpicomm, mpirank=mpirank, mpiroot=mpiroot,    &
+                                     threads=threads, errmsg=errmsg, errflg=errflg)
+                  if (errflg /= 0) return
+               end if
 
-         if (is_aerosol_aware) then
-            ! Fix initial values of aerosols
-            where(nc<0)     nc = 0.0
-            where(nwfa<0)   nwfa = 0.0
-            where(nifa<0)   nifa = 0.0
-            where(nwfa2d<0) nwfa2d = 0.0
-            where(nifa2d<0) nifa2d = 0.0
-         end if
+               ! For restart runs, the init is done here
+               if (restart) then
+                   is_initialized = .true.
+                   return
+               end if
 
-         ! Geopotential height in m2 s-2 to height in m
-         hgt = phil/con_g
+             end if only_for_first_block
 
-         ! Density of air in kg m-3 and inverse density of air
-         rho = prsl/(con_rd*tgrs)
-         orho = 1.0/rho
+             ! Fix initial values of hydrometeors
+             where(spechum<0) spechum = 0.0
+             where(qc<0)      qc = 0.0
+             where(qr<0)      qr = 0.0
+             where(qi<0)      qi = 0.0
+             where(qs<0)      qs = 0.0
+             where(qg<0)      qg = 0.0
+             where(ni<0)      ni = 0.0
+             where(nr<0)      nr = 0.0
 
-         ! Prior to calling the functions: make_DropletNumber, make_IceNumber, make_RainNumber,
-         ! the incoming mixing ratios should be converted to units of mass/num per cubic meter
-         ! rather than per kg of air.  So, to pass back to the model state variables,
-         ! they also need to be switched back to mass/number per kg of air, because
-         ! what is returned by the functions is in units of number per cubic meter.
-         ! They also need to be converted to dry mixing ratios.
+             if (is_aerosol_aware) then
+                ! Fix initial values of aerosols
+                where(nc<0)     nc = 0.0
+                where(nwfa<0)   nwfa = 0.0
+                where(nifa<0)   nifa = 0.0
+                where(nwfa2d<0) nwfa2d = 0.0
+                where(nifa2d<0) nifa2d = 0.0
+             end if
 
-         !> - Convert specific humidity/moist mixing ratios to dry mixing ratios
-         qv_mp = spechum/(1.0_kind_phys-spechum)
-         qc_mp = qc/(1.0_kind_phys-spechum)
-         qr_mp = qr/(1.0_kind_phys-spechum)
-         qi_mp = qi/(1.0_kind_phys-spechum)
-         qs_mp = qs/(1.0_kind_phys-spechum)
-         qg_mp = qg/(1.0_kind_phys-spechum)
+             ! Geopotential height in m2 s-2 to height in m
+             hgt = phil/con_g
 
-         !> - Convert number concentrations from moist to dry
-         ni_mp = ni/(1.0_kind_phys-spechum)
-         nr_mp = nr/(1.0_kind_phys-spechum)
-         if (is_aerosol_aware) then
-             nc_mp = nc/(1.0_kind_phys-spechum)
-         end if
+             ! Density of air in kg m-3 and inverse density of air
+             rho = prsl/(con_rd*tgrs)
+             orho = 1.0/rho
 
-         ! If qi is in boundary conditions but ni is not, calculate ni from qi, rho and tgrs
-         if (maxval(qi_mp)>0.0 .and. maxval(ni_mp)==0.0) then
-             ni_mp = make_IceNumber(qi_mp*rho, tgrs) * orho
-         end if
+             ! Prior to calling the functions: make_DropletNumber, make_IceNumber, make_RainNumber,
+             ! the incoming mixing ratios should be converted to units of mass/num per cubic meter
+             ! rather than per kg of air.  So, to pass back to the model state variables,
+             ! they also need to be switched back to mass/number per kg of air, because
+             ! what is returned by the functions is in units of number per cubic meter.
+             ! They also need to be converted to dry mixing ratios.
 
-         ! If ni is in boundary conditions but qi is not, reset ni to zero
-         if (maxval(ni_mp)>0.0 .and. maxval(qi_mp)==0.0) ni_mp = 0.0
+             !> - Convert specific humidity/moist mixing ratios to dry mixing ratios
+             qv_mp = spechum/(1.0_kind_phys-spechum)
+             qc_mp = qc/(1.0_kind_phys-spechum)
+             qr_mp = qr/(1.0_kind_phys-spechum)
+             qi_mp = qi/(1.0_kind_phys-spechum)
+             qs_mp = qs/(1.0_kind_phys-spechum)
+             qg_mp = qg/(1.0_kind_phys-spechum)
 
-         ! If qr is in boundary conditions but nr is not, calculate nr from qr, rho and tgrs
-         if (maxval(qr_mp)>0.0 .and. maxval(nr_mp)==0.0) then
-             nr_mp = make_RainNumber(qr_mp*rho, tgrs) * orho
-         end if
+             !> - Convert number concentrations from moist to dry
+             ni_mp = ni/(1.0_kind_phys-spechum)
+             nr_mp = nr/(1.0_kind_phys-spechum)
+             if (is_aerosol_aware) then
+                 nc_mp = nc/(1.0_kind_phys-spechum)
+             end if
 
-         ! If nr is in boundary conditions but qr is not, reset nr to zero
-         if (maxval(nr_mp)>0.0 .and. maxval(qr_mp)==0.0) nr_mp = 0.0
+             ! If qi is in boundary conditions but ni is not, calculate ni from qi, rho and tgrs
+             if (maxval(qi_mp)>0.0 .and. maxval(ni_mp)==0.0) then
+                 ni_mp = make_IceNumber(qi_mp*rho, tgrs) * orho
+             end if
 
-         !..Check for existing aerosol data, both CCN and IN aerosols.  If missing
-         !.. fill in just a basic vertical profile, somewhat boundary-layer following.
-         if (is_aerosol_aware) then
+             ! If ni is in boundary conditions but qi is not, reset ni to zero
+             if (maxval(ni_mp)>0.0 .and. maxval(qi_mp)==0.0) ni_mp = 0.0
 
-             ! CCN
-             if (MAXVAL(nwfa) .lt. eps) then
-                if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently there are no initial CCN aerosols.'
-                do i = 1, ncol
+             ! If qr is in boundary conditions but nr is not, calculate nr from qr, rho and tgrs
+             if (maxval(qr_mp)>0.0 .and. maxval(nr_mp)==0.0) then
+                 nr_mp = make_RainNumber(qr_mp*rho, tgrs) * orho
+             end if
+
+             ! If nr is in boundary conditions but qr is not, reset nr to zero
+             if (maxval(nr_mp)>0.0 .and. maxval(qr_mp)==0.0) nr_mp = 0.0
+
+             !..Check for existing aerosol data, both CCN and IN aerosols.  If missing
+             !.. fill in just a basic vertical profile, somewhat boundary-layer following.
+             if (is_aerosol_aware) then
+
+               ! CCN
+               if (MAXVAL(nwfa) .lt. eps) then
+                 if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently there are no initial CCN aerosols.'
+                 do i = 1, ncol
                    if (hgt(i,1).le.1000.0) then
-                      h_01 = 0.8
+                     h_01 = 0.8
                    elseif (hgt(i,1).ge.2500.0) then
-                      h_01 = 0.01
+                     h_01 = 0.01
                    else
-                      h_01 = 0.8*cos(hgt(i,1)*0.001 - 1.0)
+                     h_01 = 0.8*cos(hgt(i,1)*0.001 - 1.0)
                    endif
                    niCCN3 = -1.0*ALOG(naCCN1/naCCN0)/h_01
                    nwfa(i,1) = naCCN1+naCCN0*exp(-((hgt(i,2)-hgt(i,1))/1000.)*niCCN3)
                    airmass = 1./orho(i,1) * (hgt(i,2)-hgt(i,1))*area(i) ! kg
                    nwfa2d(i) = nwfa(i,1) * 0.000196 * (airmass*2.E-10)
                    do k = 2, nlev
-                      nwfa(i,k) = naCCN1+naCCN0*exp(-((hgt(i,k)-hgt(i,1))/1000.)*niCCN3)
+                     nwfa(i,k) = naCCN1+naCCN0*exp(-((hgt(i,k)-hgt(i,1))/1000.)*niCCN3)
                    enddo
-                enddo
-             else
-                if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently initial CCN aerosols are present.'
-                if (MAXVAL(nwfa2d) .lt. eps) then
+                 enddo
+               else
+                 if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently initial CCN aerosols are present.'
+                 if (MAXVAL(nwfa2d) .lt. eps) then
 ! Hard-coded switch between new (from WRFv4.0, top) and old (until WRFv3.9.1.1, bottom) surface emission rate calculations
 #if 0
                    !+---+-----------------------------------------------------------------+
@@ -312,15 +405,15 @@ module mp_thompson
                       nwfa2d(i) = nwfa2d(i)*h_01 * 1.E6
                    enddo
 #endif
-                else
-                   if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently initial CCN aerosol surface emission rates are present.'
-                endif
-             endif
+                 else
+                    if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently initial CCN aerosol surface emission rates are present.'
+                 endif
+               endif
 
-             ! IN
-             if (MAXVAL(nifa) .lt. eps) then
-                if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently there are no initial IN aerosols.'
-                do i = 1, ncol
+               ! IN
+               if (MAXVAL(nifa) .lt. eps) then
+                 if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently there are no initial IN aerosols.'
+                 do i = 1, ncol
                    if (hgt(i,1).le.1000.0) then
                       h_01 = 0.8
                    elseif (hgt(i,1).ge.2500.0) then
@@ -334,54 +427,53 @@ module mp_thompson
                    do k = 2, nlev
                       nifa(i,k) = naIN1+naIN0*exp(-((hgt(i,k)-hgt(i,1))/1000.)*niIN3)
                    enddo
-                enddo
-             else
-                if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently initial IN aerosols are present.' 
-                if (MAXVAL(nifa2d) .lt. eps) then
+                 enddo
+               else
+                 if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently initial IN aerosols are present.'
+                 if (MAXVAL(nifa2d) .lt. eps) then
                    if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently there are no initial IN aerosol surface emission rates, set to zero.'
                    ! calculate IN surface flux here, right now just set to zero
                    nifa2d = 0.
-                else
+                 else
                    if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently initial IN aerosol surface emission rates are present.'
-                endif
-             endif
+                 endif
+               endif
 
-             ! If qc is in boundary conditions but nc is not, calculate nc from qc, rho and nwfa
-             if (maxval(qc_mp)>0.0 .and. maxval(nc_mp)==0.0) then
-                nc_mp = make_DropletNumber(qc_mp*rho, nwfa) * orho
+               ! If qc is in boundary conditions but nc is not, calculate nc from qc, rho and nwfa
+               if (maxval(qc_mp)>0.0 .and. maxval(nc_mp)==0.0) then
+                 nc_mp = make_DropletNumber(qc_mp*rho, nwfa) * orho
+               end if
+
+               ! If nc is in boundary conditions but qc is not, reset nc to zero
+               if (maxval(nc_mp)>0.0 .and. maxval(qc_mp)==0.0) nc_mp = 0.0
+
+             else
+
+               ! Constant droplet concentration for single moment cloud water as in
+               ! module_mp_thompson.F90, only needed for effective radii calculation
+               nc_mp = Nt_c/rho
+
              end if
 
-             ! If nc is in boundary conditions but qc is not, reset nc to zero
-             if (maxval(nc_mp)>0.0 .and. maxval(qc_mp)==0.0) nc_mp = 0.0
-
-         else
-
-             ! Constant droplet concentration for single moment cloud water as in
-             ! module_mp_thompson.F90, only needed for effective radii calculation
-             nc_mp = Nt_c/rho
-
-         end if
-
-         ! Calculate initial cloud effective radii if requested
-         if (present(re_cloud) .and. present(re_ice) .and. present(re_snow)) then
+             ! Calculate initial cloud effective radii if requested
              do i = 1, ncol
-                 do k = 1, nlev
-                     re_cloud(i,k) = 2.49E-6
-                     re_ice(i,k)   = 4.99E-6
-                     re_snow(i,k)  = 9.99E-6
-                 end do
+               do k = 1, nlev
+                 re_cloud(i,k) = 2.49E-6
+                 re_ice(i,k)   = 4.99E-6
+                 re_snow(i,k)  = 9.99E-6
+               end do
              end do
              do i = 1, ncol
-                 call calc_effectRad (tgrs(i,:), prsl(i,:), qv_mp(i,:), qc_mp(i,:),     &
-                                      nc_mp(i,:), qi_mp(i,:), ni_mp(i,:), qs_mp(i,:),   &
-                                      re_cloud(i,:), re_ice(i,:), re_snow(i,:), kts, kte)
+               call calc_effectRad (tgrs(i,:), prsl(i,:), qv_mp(i,:), qc_mp(i,:),     &
+                                    nc_mp(i,:), qi_mp(i,:), ni_mp(i,:), qs_mp(i,:),   &
+                                    re_cloud(i,:), re_ice(i,:), re_snow(i,:), 1, nlev)
              end do
              do i = 1, ncol
-                 do k = 1, nlev
-                     re_cloud(i,k) = MAX(2.49E-6, MIN(re_cloud(i,k), 50.E-6))
-                     re_ice(i,k)   = MAX(4.99E-6, MIN(re_ice(i,k), 125.E-6))
-                     re_snow(i,k)  = MAX(9.99E-6, MIN(re_snow(i,k), 999.E-6))
-                 end do
+               do k = 1, nlev
+                 re_cloud(i,k) = MAX(2.49E-6, MIN(re_cloud(i,k), 50.E-6))
+                 re_ice(i,k)   = MAX(4.99E-6, MIN(re_ice(i,k), 125.E-6))
+                 re_snow(i,k)  = MAX(9.99E-6, MIN(re_snow(i,k), 999.E-6))
+               end do
              end do
              ! Convert to micron: required for bit-for-bit identical restarts;
              ! otherwise entering mp_thompson_init and converting mu to m and
@@ -389,22 +481,30 @@ module mp_thompson
              re_cloud = 1.0E6*re_cloud
              re_ice   = 1.0E6*re_ice
              re_snow  = 1.0E6*re_snow
-         else if (.not.present(re_cloud) .and. .not.present(re_ice) .and. .not.present(re_snow)) then
-             ! Do nothing
-         else
-             write(errmsg,fmt='(*(a))') 'Logic error in mp_thompson_run:',  &
-                                        ' all or none of the following optional', &
-                                        ' arguments are required: re_cloud, re_ice, re_snow'
-             errflg = 1
-             return
-         end if
 
-         !> - Convert number concentrations from dry to moist
-         ni = ni_mp/(1.0_kind_phys+qv_mp)
-         nr = nr_mp/(1.0_kind_phys+qv_mp)
-         if (is_aerosol_aware) then
-             nc = nc_mp/(1.0_kind_phys+qv_mp)
-         end if
+             !> - Convert number concentrations from dry to moist
+             ni = ni_mp/(1.0_kind_phys+qv_mp)
+             nr = nr_mp/(1.0_kind_phys+qv_mp)
+             if (is_aerosol_aware) then
+                 nc = nc_mp/(1.0_kind_phys+qv_mp)
+             end if
+
+             deallocate(qv_mp)
+             deallocate(qc_mp)
+             deallocate(qr_mp)
+             deallocate(qi_mp)
+             deallocate(qs_mp)
+             deallocate(qg_mp)
+             deallocate(ni_mp)
+             deallocate(nr_mp)
+             deallocate(nc_mp)
+             deallocate(hgt  )
+             deallocate(rho  )
+             deallocate(orho )
+
+           !end associate associate_arrays
+
+         end do block_loop
 
          is_initialized = .true.
 
@@ -552,7 +652,7 @@ module mp_thompson
          qi_mp = qi/(1.0_kind_phys-spechum)
          qs_mp = qs/(1.0_kind_phys-spechum)
          qg_mp = qg/(1.0_kind_phys-spechum)
-         
+
          !> - Convert number concentrations from moist to dry
          ni_mp = ni/(1.0_kind_phys-spechum)
          nr_mp = nr/(1.0_kind_phys-spechum)

--- a/physics/mp_thompson.meta.backup.before.workaround
+++ b/physics/mp_thompson.meta.backup.before.workaround
@@ -1,122 +1,18 @@
 [ccpp-arg-table]
   name = mp_thompson_init
   type = scheme
-[Data]
-  standard_name = GFS_data_type_instance_all_blocks
-  long_name = instance of derived type GFS_data_type
-  units = DDT
-  dimensions = (ccpp_block_number)
-  type = GFS_data_type
-  intent = inout
-  optional = F
-[ntqv]
-  standard_name = index_for_water_vapor
-  long_name = tracer index for water vapor (specific humidity)
-  units = index
+[ncol]
+  standard_name = horizontal_loop_extent
+  long_name = horizontal loop extent
+  units = count
   dimensions = ()
   type = integer
   intent = in
   optional = F
-[ntcw]
-  standard_name = index_for_liquid_cloud_condensate
-  long_name = tracer index for cloud condensate (or liquid water)
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[ntrw]
-  standard_name = index_for_rain_water
-  long_name = tracer index for rain water
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[ntiw]
-  standard_name = index_for_ice_cloud_condensate
-  long_name = tracer index for  ice water
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[ntsw]
-  standard_name = index_for_snow_water
-  long_name = tracer index for snow water
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[ntgl]
-  standard_name = index_for_graupel
-  long_name = tracer index for graupel
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[ntinc]
-  standard_name = index_for_ice_cloud_number_concentration
-  long_name = tracer index for ice    number concentration
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[ntrnc]
-  standard_name = index_for_rain_number_concentration
-  long_name = tracer index for rain   number concentration
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[ntlnc]
-  standard_name = index_for_liquid_cloud_number_concentration
-  long_name = tracer index for liquid number concentration
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[ntwa]
-  standard_name = index_for_water_friendly_aerosols
-  long_name = tracer index for water friendly aerosol
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[ntia]
-  standard_name = index_for_ice_friendly_aerosols
-  long_name = tracer index for ice friendly aerosol
-  units = index
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[nleffr]
-  standard_name = index_for_cloud_liquid_water_effective_radius
-  long_name = the index of cloud liquid water effective radius in phy_f3d
-  units = 
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[nieffr]
-  standard_name = index_for_ice_effective_radius
-  long_name = the index of ice effective radius in phy_f3d
-  units = 
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[nseffr]
-  standard_name = index_for_snow_effective_radius
-  long_name = the index of snow effective radius in phy_f3d
-  units = 
+[nlev]
+  standard_name = vertical_dimension
+  long_name = number of vertical levels
+  units = count
   dimensions = ()
   type = integer
   intent = in
@@ -163,6 +59,78 @@
   type = integer
   intent = in
   optional = F
+[spechum]
+  standard_name = water_vapor_specific_humidity
+  long_name = water vapor specific humidity
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[qc]
+  standard_name = cloud_condensed_water_mixing_ratio
+  long_name = cloud water mixing ratio wrt dry+vapor (no condensates)
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[qr]
+  standard_name = rain_water_mixing_ratio
+  long_name = rain water mixing ratio wrt dry+vapor (no condensates)
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[qi]
+  standard_name = ice_water_mixing_ratio
+  long_name = ice water mixing ratio wrt dry+vapor (no condensates)
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[qs]
+  standard_name = snow_water_mixing_ratio
+  long_name = snow water mixing ratio wrt dry+vapor (no condensates)
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[qg]
+  standard_name = graupel_mixing_ratio
+  long_name = graupel mixing ratio wrt dry+vapor (no condensates)
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[ni]
+  standard_name = ice_number_concentration
+  long_name = ice number concentration
+  units = kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[nr]
+  standard_name = rain_number_concentration
+  long_name = rain number concentration
+  units = kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [is_aerosol_aware]
   standard_name = flag_for_aerosol_physics
   long_name = flag for aerosol-aware physics
@@ -171,6 +139,114 @@
   type = logical
   intent = in
   optional = F
+[nc]
+  standard_name = cloud_droplet_number_concentration
+  long_name = cloud droplet number concentration
+  units = kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = T
+[nwfa2d]
+  standard_name = tendency_of_water_friendly_aerosols_at_surface
+  long_name = instantaneous fake water-friendly surface aerosol source
+  units = kg-1 s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = T
+[nifa2d]
+  standard_name = tendency_of_ice_friendly_aerosols_at_surface
+  long_name = instantaneous fake ice-friendly surface aerosol source
+  units = kg-1 s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = T
+[nwfa]
+  standard_name = water_friendly_aerosol_number_concentration
+  long_name = number concentration of water-friendly aerosols
+  units = kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = T
+[nifa]
+  standard_name = ice_friendly_aerosol_number_concentration
+  long_name = number concentration of ice-friendly aerosols
+  units = kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = T
+[tgrs]
+  standard_name = air_temperature
+  long_name = model layer mean temperature
+  units = K
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[prsl]
+  standard_name = air_pressure
+  long_name = mean layer pressure
+  units = Pa
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[phil]
+  standard_name = geopotential
+  long_name = geopotential at model layer centers
+  units = m2 s-2
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[area]
+  standard_name = cell_area
+  long_name = area of the grid cell
+  units = m2
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[re_cloud]
+  standard_name = effective_radius_of_stratiform_cloud_liquid_water_particle_in_um
+  long_name = eff. radius of cloud liquid water particle in micrometer
+  units = um
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = T
+[re_ice]
+  standard_name = effective_radius_of_stratiform_cloud_ice_particle_in_um
+  long_name = eff. radius of cloud ice water particle in micrometer
+  units = um
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = T
+[re_snow]
+  standard_name = effective_radius_of_stratiform_cloud_snow_particle_in_um
+  long_name = effective radius of cloud snow particle in micrometer
+  units = um
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = T
 [mpicomm]
   standard_name = mpi_comm
   long_name = MPI communicator
@@ -199,6 +275,14 @@
   standard_name = omp_threads
   long_name = number of OpenMP threads available to scheme
   units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[blkno]
+  standard_name = ccpp_block_number
+  long_name = for explicit data blocking: block number of this block
+  units = index
   dimensions = ()
   type = integer
   intent = in

--- a/physics/mp_thompson_post.meta
+++ b/physics/mp_thompson_post.meta
@@ -92,6 +92,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[ttendlim]
+  standard_name = limit_for_temperature_tendency_for_microphysics
+  long_name = temperature tendency limiter per physics time step
+  units = K s-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [kdt]
   standard_name = index_of_time_step
   long_name = current forecast iteration


### PR DESCRIPTION
This PR is a workaround/bugfix for the correct initialization of Thompson MP aerosol surface emissions and 2nd moments (number concentrations). The issue discovered was that the initialization is thread-independent and needs to run over all blocks concurrently. Right now, this can only be achieved by making the proposed changes (which I consider as nasty and temporary only).

Once we removed the CCPP dynamic build entirely (next to do), I can work on reverting the code changes so that they basically look like the previous code, but run over all blocks concurrently.

Attached below are images from ncview showing nwfa2d after one timestep.

Regression testing still needs to be done. No changes required in ccpp-framework, fv3atm or ufs-weather-model.
