### PR TITLE
Cleanup of Thompson MP cloud effective radii calculation

### DIFF
--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -728,7 +728,7 @@
                    qc_mp(i,k) = (clw(i,k,2)-save_qc(i,k))/(1.0_kind_phys-spechum(i,k))
                    !> - Convert number concentration from moist to dry
                    nc_mp(i,k) = gq0(i,k,ntlnc)/(1.0_kind_phys-spechum(i,k))
-                   nc_mp(i,k) = nc_mp(i,k) + max(0.0, make_DropletNumber(qc_mp(i,k) * rho_dryair(i,k), nwfa(i,k)) * (1.0/rho_dryair(i,k)))
+                   nc_mp(i,k) = max(0.0, nc_mp(i,k) + make_DropletNumber(qc_mp(i,k) * rho_dryair(i,k), nwfa(i,k)) * (1.0/rho_dryair(i,k)))
                    !> - Convert number concentrations from dry to moist
                    gq0(i,k,ntlnc) = nc_mp(i,k)/(1.0_kind_phys+qv_mp(i,k))
                  endif
@@ -737,7 +737,7 @@
                    qi_mp(i,k) = (clw(i,k,1)-save_qi(i,k))/(1.0_kind_phys-spechum(i,k))
                    !> - Convert number concentration from moist to dry
                    ni_mp(i,k) = gq0(i,k,ntinc)/(1.0_kind_phys-spechum(i,k)) 
-                   ni_mp(i,k) = ni_mp(i,k) + max(0.0, make_IceNumber(qi_mp(i,k) * rho_dryair(i,k), save_tcp(i,k)) * (1.0/rho_dryair(i,k)))
+                   ni_mp(i,k) = max(0.0, ni_mp(i,k) + make_IceNumber(qi_mp(i,k) * rho_dryair(i,k), save_tcp(i,k)) * (1.0/rho_dryair(i,k)))
                    !> - Convert number concentrations from dry to moist
                    gq0(i,k,ntinc) = ni_mp(i,k)/(1.0_kind_phys+qv_mp(i,k))
                  endif

--- a/physics/mp_thompson.meta
+++ b/physics/mp_thompson.meta
@@ -223,7 +223,7 @@
 [re_cloud]
   standard_name = effective_radius_of_stratiform_cloud_liquid_water_particle_in_um
   long_name = eff. radius of cloud liquid water particle in micrometer
-  units = um
+  units = m
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
@@ -232,7 +232,7 @@
 [re_ice]
   standard_name = effective_radius_of_stratiform_cloud_ice_particle_in_um
   long_name = eff. radius of cloud ice water particle in micrometer
-  units = um
+  units = m
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
@@ -241,7 +241,7 @@
 [re_snow]
   standard_name = effective_radius_of_stratiform_cloud_snow_particle_in_um
   long_name = effective radius of cloud snow particle in micrometer
-  units = um
+  units = m
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys


### PR DESCRIPTION
Changes in this PR:
- physics/mp_thompson.{F90,meta}: cleanup use of optional arguments for cloud effective radii
- physics/GFS_rrtmg_pre.F90: cleanup calculation of cloud effective radii, fix bugs

Associated PRs:
https://github.com/NOAA-GSD/ccpp-physics/pull/30
https://github.com/NOAA-GSD/fv3atm/pull/31
https://github.com/NOAA-GSD/ufs-weather-model/pull/24

For regression testing information, see https://github.com/NOAA-GSD/ufs-weather-model/pull/24.