### PR TITLE
MYNN-EDMF wrapper bug fix: mis-handling ozone when using GFDL microphysics

### DIFF
--- a/physics/module_MYNNPBL_wrapper.F90
+++ b/physics/module_MYNNPBL_wrapper.F90
@@ -429,6 +429,7 @@ SUBROUTINE mynnedmf_wrapper_run(        &
                 qni(i,k)   = 0.
                 qnwfa(i,k) = 0.
                 qnifa(i,k) = 0.
+                ozone(i,k) = qgrs_ozone(i,k)
             enddo
           enddo
         else
@@ -456,6 +457,7 @@ SUBROUTINE mynnedmf_wrapper_run(        &
                 qni(i,k)   = 0.
                 qnwfa(i,k) = 0.
                 qnifa(i,k) = 0.
+                ozone(i,k) = qgrs_ozone(i,k)
             enddo
           enddo
         endif


### PR DESCRIPTION
Simple 2-line modification to correctly use ozone when the MYNN-EDMF is used with the GFDL microphysics scheme. This has no impact on the HRRR physics suite.