### PR TITLE
Physics changes made for/during HFIP 2020

### DIFF
--- a/physics/cu_gf_driver.F90
+++ b/physics/cu_gf_driver.F90
@@ -190,10 +190,10 @@ contains
    real(kind=kind_phys), dimension (im)  :: hfx,qfx
    real(kind=kind_phys) tem,tem1,tf,tcr,tcrf
 
-   parameter (tf=243.16, tcr=270.16, tcrf=1.0/(tcr-tf))
+  !parameter (tf=243.16, tcr=270.16, tcrf=1.0/(tcr-tf)) ! FV3 original
   !parameter (tf=263.16, tcr=273.16, tcrf=1.0/(tcr-tf))
   !parameter (tf=233.16, tcr=263.16, tcrf=1.0/(tcr-tf))
-  !parameter (tf=258.16, tcr=273.16, tcrf=1.0/(tcr-tf)) ! as fim
+  parameter (tf=258.16, tcr=273.16, tcrf=1.0/(tcr-tf)) ! as fim, HCB tuning
   ! initialize ccpp error handling variables
      errmsg = ''
      errflg = 0


### PR DESCRIPTION
- All changes in GF (1. set c0 = 0.02 for mid-clouds. 2. changes water-ice transition temperature to what was used in FIM [transition now occurs at 258 instead of 248K])
- Also does some clean-up for how c0 is used in the code. 