### PR TITLE
physics/sfcsub.F: reduce length of message string for prettier output

### DIFF
--- a/physics/sfcsub.F
+++ b/physics/sfcsub.F
@@ -43,8 +43,8 @@
       implicit none
       character(len=*), intent(in) :: prefix
       integer, intent(in) :: index
-      ! Safety measure: prevent writing out of bounds, use a longer string
-      character(len=128) :: message
+      ! Safety measure: prevent writing out of bounds, use a longer string than 8 characters
+      character(len=16) :: message
       write(message,fmt='(a,a,i0)') trim(prefix), '-', index
       end function message
 


### PR DESCRIPTION
physics/sfcsub.F: reduce length of message string for prettier output

Associated PRs:

https://github.com/NOAA-GSD/ccpp-physics/pull/52
https://github.com/NOAA-GSD/fv3atm/pull/48
https://github.com/NOAA-GSD/ufs-weather-model/pull/40

For regression testing information, see https://github.com/NOAA-GSD/ufs-weather-model/pull/40.