### PR TITLE
Only use wetdpc_shal and wetdpc_deep if they're allocated.

### DIFF
--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -78,7 +78,7 @@
      &    CNV_DQLDT,CLCN,CNV_FICE,CNV_NDROP,CNV_NICE,mp_phys,mp_phys_mg,&
      &    clam,c0s,c1,betal,betas,evfact,evfactl,pgcon,asolfac,         &
      &    do_ca, ca_closure, ca_entr, ca_trigger, nthresh, ca_deep,     &
-     &    rainevap,wetdpc_deep,                                         &
+     &    rainevap,wetdpc_deep,cplchm,                                  &
      &    errmsg,errflg)
 !
       use machine , only : kind_phys
@@ -236,7 +236,8 @@ c  physical parameters
      &                     ctr(im,km,ntr), ctro(im,km,ntr)
 !  for aerosol transport
       real(kind=kind_phys) qaero(im,km,ntc)
-      real(kind=kind_phys) wetdpc_deep(im,ntc)
+      real(kind=kind_phys), intent(inout), optional :: wetdpc_deep(:,:)
+      logical, intent(in) :: cplchm
 !  for updraft velocity calculation
       real(kind=kind_phys) wu2(im,km),     buo(im,km),    drag(im,km)
       real(kind=kind_phys) wc(im),         scaldfunc(im), sigmagfm(im)
@@ -341,7 +342,9 @@ c
         vshear(i) = 0.
         rainevap(i) = 0.
         gdx(i) = sqrt(garea(i))
-        wetdpc_deep(i,:) = 0.
+        if(cplchm) then
+           wetdpc_deep(i,:) = 0.
+        endif
       enddo
 !
       if (hwrf_samfdeep) then
@@ -2872,9 +2875,11 @@ c
                !if (k <= kmax(i)) qtr(i,k,kk) = qaero(i,k,n)
                 if (k <= kmax(i)) then !lzhang
                 !convert wetdeposition into ug/m2/s !lzhang
-                wetdpc_deep(i,n) = wetdpc_deep(i,n)
-     &   + ((qtr(i,k,kk)-qaero(i,k,n))*delp(i,k)/(grav*delt))
-                qtr(i,k,kk) = qaero(i,k,n)
+                  if(cplchm) then
+                    wetdpc_deep(i,n) = wetdpc_deep(i,n)
+     &              + ((qtr(i,k,kk)-qaero(i,k,n))*delp(i,k)/(grav*delt))
+                  endif
+                  qtr(i,k,kk) = qaero(i,k,n)
                 endif
               endif
             enddo

--- a/physics/samfdeepcnv.meta
+++ b/physics/samfdeepcnv.meta
@@ -637,6 +637,14 @@
   kind = kind_phys
   intent = out
   optional = F
+[cplchm]
+  standard_name = flag_for_chemistry_coupling
+  long_name = flag controlling cplchm collection (default off)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/samfshalcnv.f
+++ b/physics/samfshalcnv.f
@@ -54,7 +54,7 @@
      &     t0c,delt,ntk,ntr,delp,                                       &
      &     prslp,psp,phil,qtr,q1,t1,u1,v1,fscav,                        &
      &     rn,kbot,ktop,kcnv,islimsk,garea,                             &
-     &     dot,ncloud,hpbl,ud_mf,dt_mf,cnvw,cnvc,wetdpc_shal,           &
+     &     dot,ncloud,hpbl,ud_mf,dt_mf,cnvw,cnvc,wetdpc_shal,cplchm,    &
      &     clam,c0s,c1,pgcon,asolfac,hwrf_samfshal,errmsg,errflg)
 !
       use machine , only : kind_phys
@@ -180,7 +180,8 @@ c  local variables and arrays
      &                     ctr(im,km,ntr), ctro(im,km,ntr)
 !  for aerosol transport
       real(kind=kind_phys) qaero(im,km,ntc)
-      real(kind=kind_phys) wetdpc_shal(im,ntc)
+      real(kind=kind_phys), intent(inout), optional :: wetdpc_shal(:,:)
+      logical, intent(in) :: cplchm
 !  for updraft velocity calculation
       real(kind=kind_phys) wu2(im,km),     buo(im,km),    drag(im,km)
       real(kind=kind_phys) wc(im),         scaldfunc(im), sigmagfm(im)
@@ -286,7 +287,9 @@ c
         cina(i) = 0.
         vshear(i) = 0.
         gdx(i) = sqrt(garea(i))
-        wetdpc_shal(i,:)=0.
+        if(cplchm) then
+          wetdpc_shal(i,:)=0.
+        endif
        enddo
       endif
 !!
@@ -1849,9 +1852,11 @@ c
                !if (k <= kmax(i)) qtr(i,k,kk) = qaero(i,k,n)
                 if (k <= kmax(i)) then !lzhang
                 !convert wetdeposition into ug/m2/s !lzhang
-                wetdpc_shal(i,n)=wetdpc_shal(i,n)
-     &  + ((qtr(i,k,kk)-qaero(i,k,n))*delp(i,k)/(grav*delt))
-                qtr(i,k,kk) = qaero(i,k,n)
+                  if(cplchm) then
+                    wetdpc_shal(i,n)=wetdpc_shal(i,n)
+     &              +((qtr(i,k,kk)-qaero(i,k,n))*delp(i,k)/(grav*delt))
+                  endif
+                  qtr(i,k,kk) = qaero(i,k,n)
                 endif
               endif
             enddo

--- a/physics/samfshalcnv.meta
+++ b/physics/samfshalcnv.meta
@@ -427,6 +427,14 @@
   kind = kind_phys
   intent = out
   optional = F
+[cplchm]
+  standard_name = flag_for_chemistry_coupling
+  long_name = flag controlling cplchm collection (default off)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP


### PR DESCRIPTION
When cplchm=.false., the wetdpc_shal and wetdpc_deep are not allocated. This bugfix prevents samfshal and samfdeep from using those variables unless they're allocated.