### PR TITLE
multipliers to amplitude of emissions perturbations in four wrappers

### DIFF
--- a/gsdchem/gsd_chem_anthropogenic_wrapper.F90
+++ b/gsdchem/gsd_chem_anthropogenic_wrapper.F90
@@ -42,7 +42,7 @@ contains
                    pr3d, ph3d,phl3d, prl3d, tk3d, spechum,emi_in,                       &
                    ntrac,ntso2,ntsulf,ntpp25,ntbc1,ntoc1,ntpp10,                        &
                    gq0,qgrs,abem,chem_opt_in,kemit_in,                                  &
-                   emis_multiplier, do_sppt_emis, ca_global_emis,                       &
+                   emis_amp_anthro, emis_multiplier, do_sppt_emis, ca_global_emis,      &
                    errmsg,errflg)
 
     implicit none
@@ -52,7 +52,7 @@ contains
     integer,        intent(in) :: ntrac
     integer,        intent(in) :: ntso2,ntpp25,ntbc1,ntoc1,ntpp10
     integer,        intent(in) :: ntsulf
-    real(kind_phys),intent(in) :: dt
+    real(kind_phys),intent(in) :: dt, emis_amp_anthro
 
     logical,        intent(in) :: ca_global_emis, do_sppt_emis
     real, optional, intent(in) :: emis_multiplier(:)
@@ -104,7 +104,7 @@ contains
 
     if(do_sppt_emis .or. ca_global_emis) then
       do i = ims, im
-        random_factor(i,jms) = emis_multiplier(i)
+        random_factor(i,jms) = min(10.0,max(0.0,(emis_multiplier(i)-1.0)*emis_amp_anthro + 1.0))
       enddo
     else
       random_factor = 1.0

--- a/gsdchem/gsd_chem_anthropogenic_wrapper.meta
+++ b/gsdchem/gsd_chem_anthropogenic_wrapper.meta
@@ -220,6 +220,15 @@
   type = integer
   intent = in
   optional = F
+[emis_amp_anthro]
+  standard_name = anthropogenic_emissions_perturbation_amplitude
+  long_name = multiplier of emissions random perturbation of anthropogenic emissions
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [emis_multiplier]
   standard_name = gsd_chem_ca_global_emis_multiplier
   long_name = fraction of emissions to generate based on cellular automata

--- a/gsdchem/gsd_chem_dust_wrapper.F90
+++ b/gsdchem/gsd_chem_dust_wrapper.F90
@@ -51,7 +51,7 @@ contains
                    gq0,qgrs,duem,                                               &
                    chem_opt_in,dust_opt_in,dust_calcdrag_in,                    &
                    dust_alpha_in,dust_gamma_in,                                 &
-                   emis_multiplier, do_sppt_emis, ca_global_emis,               &
+                   emis_amp_dust, emis_multiplier, do_sppt_emis, ca_global_emis,&
                    errmsg,errflg)
 
     implicit none
@@ -60,7 +60,7 @@ contains
     integer,        intent(in) :: im,kte,kme,ktau,nsoil
     integer,        intent(in) :: nseasalt,ntrac
     integer,        intent(in) :: ntdust1,ntdust2,ntdust3,ntdust4,ntdust5,ndust
-    real(kind_phys),intent(in) :: dt
+    real(kind_phys),intent(in) :: dt, emis_amp_dust
 
     logical,        intent(in) :: ca_global_emis, do_sppt_emis
     real, optional, intent(in) :: emis_multiplier(:)
@@ -137,7 +137,7 @@ contains
 
     if(do_sppt_emis .or. ca_global_emis) then
       do i = ims, im
-        random_factor(i,jms) = emis_multiplier(i)
+        random_factor(i,jms) = min(10.0,max(0.0,(emis_multiplier(i)-1.0)*emis_amp_dust + 1.0))
       enddo
     else
       random_factor = 1.0

--- a/gsdchem/gsd_chem_dust_wrapper.meta
+++ b/gsdchem/gsd_chem_dust_wrapper.meta
@@ -439,6 +439,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[emis_amp_dust]
+  standard_name = dust_emissions_perturbation_amplitude
+  long_name = multiplier of emissions random perturbation of dust emissions
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [emis_multiplier]
   standard_name = gsd_chem_ca_global_emis_multiplier
   long_name = fraction of emissions to generate based on cellular automata

--- a/gsdchem/gsd_chem_plume_wrapper.F90
+++ b/gsdchem/gsd_chem_plume_wrapper.F90
@@ -46,15 +46,15 @@ contains
                    ntrac,ntso2,ntpp25,ntbc1,ntoc1,ntpp10,                        &
                    gq0,qgrs,ebu,abem,                                            &
                    biomass_burn_opt_in,plumerise_flag_in,plumerisefire_frq_in,   &
-                   emis_multiplier, do_sppt_emis, ca_global_emis,                &
-                   errmsg,errflg)
+                   emis_amp_plume, emis_multiplier, do_sppt_emis,                &
+                   ca_global_emis, errmsg,errflg)
 
     implicit none
 
 
     integer,        intent(in) :: im,kte,kme,ktau
     integer,        intent(in) :: ntrac,ntso2,ntpp25,ntbc1,ntoc1,ntpp10
-    real(kind_phys),intent(in) :: dt
+    real(kind_phys),intent(in) :: dt, emis_amp_plume
 
     integer, parameter :: ids=1,jds=1,jde=1, kds=1
     integer, parameter :: ims=1,jms=1,jme=1, kms=1
@@ -177,7 +177,7 @@ contains
 
       if(plumerise_flag == FIRE_OPT_GBBEPx .and. (do_sppt_emis .or. ca_global_emis)) then
         do i = ims, im
-          random_factor(i) = emis_multiplier(i)
+          random_factor(i) = min(10.0,max(0.0,(emis_multiplier(i)-1.0)*emis_amp_plume + 1.0))
         enddo
       endif
 

--- a/gsdchem/gsd_chem_plume_wrapper.meta
+++ b/gsdchem/gsd_chem_plume_wrapper.meta
@@ -273,6 +273,13 @@
   type = integer
   intent = in
   optional = F
+[emis_amp_plume]
+  standard_name = plume_emissions_perturbation_amplitude
+  long_name = multiplier of emissions random perturbation of plume rise emissions
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
 [emis_multiplier]
   standard_name = gsd_chem_ca_global_emis_multiplier
   long_name = fraction of emissions to generate based on cellular automata

--- a/gsdchem/gsd_chem_seas_wrapper.F90
+++ b/gsdchem/gsd_chem_seas_wrapper.F90
@@ -55,9 +55,8 @@ contains
                    land, u10m, v10m, ustar, rlat, rlon, tskin,                &
                    pr3d, ph3d,prl3d, tk3d, us3d, vs3d, spechum,               &
                    nseasalt,ntrac,ntss1,ntss2,ntss3,ntss4,ntss5,              &
-                   gq0,qgrs,ssem,seas_opt_in,                                 &
-                   emis_multiplier, ca1, ca_global_emis, do_sppt_emis, sppt_wts, &
-                   errmsg,errflg)
+                   gq0,qgrs,ssem,seas_opt_in, emis_amp_seas, emis_multiplier, &
+                   ca1, ca_global_emis, do_sppt_emis, sppt_wts, errmsg, errflg)
 
     implicit none
 
@@ -68,7 +67,7 @@ contains
 
     logical,        intent(in) :: ca_global_emis, do_sppt_emis
     real, optional, intent(inout) :: emis_multiplier(:)
-    real, intent(in)    :: ca1(im)
+    real, intent(in)    :: ca1(im), emis_amp_seas
     real(kind_phys), optional, intent(in) :: sppt_wts(:,:)
 
 
@@ -127,8 +126,7 @@ contains
 
     if (do_sppt_emis) then
       do i = ims, im
-        emis_multiplier(i) = max(0.5,min(1.5,sppt_wts(i,kme/2)))
-        random_factor(i,jms) = emis_multiplier(i)
+        emis_multiplier(i) = sppt_wts(i,kme/2)
       enddo
     elseif (ca_global_emis) then
       do i = ims, im
@@ -138,8 +136,13 @@ contains
         else
           ca1_scaled=1.0/0.9
         endif
-        emis_multiplier(i) = max(0.5,min(1.5,emis_multiplier(i)*0.95 + ca1_scaled*0.05))
-        random_factor(i,jms) = emis_multiplier(i)
+        emis_multiplier(i) = max(0.8,min(1.2,emis_multiplier(i)*0.95 + ca1_scaled*0.05))
+      enddo
+    endif
+
+    if(do_sppt_emis .or. ca_global_emis) then
+      do i=ims,im
+        random_factor(i,jms) = min(10.0,max(0.0,(emis_multiplier(i)-1.0)*emis_amp_seas + 1.0))
       enddo
     endif
 

--- a/gsdchem/gsd_chem_seas_wrapper.meta
+++ b/gsdchem/gsd_chem_seas_wrapper.meta
@@ -333,6 +333,15 @@
   type = integer
   intent = in
   optional = F
+[emis_amp_seas]
+  standard_name = sea_spray_emissions_perturbation_amplitude
+  long_name = multiplier of emissions random perturbation of sea salt emissions
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [emis_multiplier]
   standard_name = gsd_chem_ca_global_emis_multiplier
   long_name = fraction of emissions to generate based on cellular automata


### PR DESCRIPTION
Allow different chemical emissions' random perturbations to vary, adjustable by `emis_amp_dust`, `emis_amp_plume`, `emis_amp_seas`, and `emis_amp_anthro`