### PR TITLE
gsd-chem stochastic emissions: scale factor, remove CA support, remove emis_multiplier

### DIFF
--- a/gsdchem/gsd_chem_anthropogenic_wrapper.F90
+++ b/gsdchem/gsd_chem_anthropogenic_wrapper.F90
@@ -41,7 +41,7 @@ contains
     subroutine gsd_chem_anthropogenic_wrapper_run(im, kte, kme, ktau, dt,               &
                    pr3d, ph3d,phl3d, prl3d, tk3d, spechum,emi_in,                       &
                    ntrac,ntso2,ntsulf,ntpp25,ntbc1,ntoc1,ntpp10,                        &
-                   gq0,qgrs,abem,chem_opt_in,kemit_in,                                  &
+                   gq0,qgrs,abem,chem_opt_in,kemit_in,pert_scale_anthro,                &
                    emis_amp_anthro, emis_multiplier, do_sppt_emis, ca_global_emis,      &
                    errmsg,errflg)
 
@@ -52,7 +52,7 @@ contains
     integer,        intent(in) :: ntrac
     integer,        intent(in) :: ntso2,ntpp25,ntbc1,ntoc1,ntpp10
     integer,        intent(in) :: ntsulf
-    real(kind_phys),intent(in) :: dt, emis_amp_anthro
+    real(kind_phys),intent(in) :: dt, emis_amp_anthro, pert_scale_anthro
 
     logical,        intent(in) :: ca_global_emis, do_sppt_emis
     real, optional, intent(in) :: emis_multiplier(:)
@@ -104,7 +104,7 @@ contains
 
     if(do_sppt_emis .or. ca_global_emis) then
       do i = ims, im
-        random_factor(i,jms) = min(10.0,max(0.0,(emis_multiplier(i)-1.0)*emis_amp_anthro + 1.0))
+        random_factor(i,jms) = min(10.0,max(0.0,((emis_multiplier(i)-1.0)*emis_amp_anthro + 1.0)*pert_scale_anthro))
       enddo
     else
       random_factor = 1.0

--- a/gsdchem/gsd_chem_anthropogenic_wrapper.F90
+++ b/gsdchem/gsd_chem_anthropogenic_wrapper.F90
@@ -42,8 +42,7 @@ contains
                    pr3d, ph3d,phl3d, prl3d, tk3d, spechum,emi_in,                       &
                    ntrac,ntso2,ntsulf,ntpp25,ntbc1,ntoc1,ntpp10,                        &
                    gq0,qgrs,abem,chem_opt_in,kemit_in,pert_scale_anthro,                &
-                   emis_amp_anthro, emis_multiplier, do_sppt_emis, ca_global_emis,      &
-                   errmsg,errflg)
+                   emis_amp_anthro,do_sppt_emis,sppt_wts,errmsg,errflg)
 
     implicit none
 
@@ -53,9 +52,8 @@ contains
     integer,        intent(in) :: ntso2,ntpp25,ntbc1,ntoc1,ntpp10
     integer,        intent(in) :: ntsulf
     real(kind_phys),intent(in) :: dt, emis_amp_anthro, pert_scale_anthro
-
-    logical,        intent(in) :: ca_global_emis, do_sppt_emis
-    real, optional, intent(in) :: emis_multiplier(:)
+    real(kind_phys), optional, intent(in) :: sppt_wts(:,:)
+    logical,        intent(in) :: do_sppt_emis
 
     integer, parameter :: ids=1,jds=1,jde=1, kds=1
     integer, parameter :: ims=1,jms=1,jme=1, kms=1
@@ -102,10 +100,8 @@ contains
    !ppm2ugkg(p_so2 ) = 1.e+03_kind_phys * mw_so2_aer / mwdry
     ppm2ugkg(p_sulf) = 1.e+03_kind_phys * mw_so4_aer / mwdry
 
-    if(do_sppt_emis .or. ca_global_emis) then
-      do i = ims, im
-        random_factor(i,jms) = min(10.0,max(0.0,((emis_multiplier(i)-1.0)*emis_amp_anthro + 1.0)*pert_scale_anthro))
-      enddo
+    if(do_sppt_emis) then
+      random_factor(:,jms) = pert_scale_anthro*max(min(1+(sppt_wts(:,kme/2)-1)*emis_amp_anthro,2.0),0.0)
     else
       random_factor = 1.0
     endif

--- a/gsdchem/gsd_chem_anthropogenic_wrapper.meta
+++ b/gsdchem/gsd_chem_anthropogenic_wrapper.meta
@@ -238,29 +238,21 @@
   kind = kind_phys
   intent = in
   optional = F
-[emis_multiplier]
-  standard_name = gsd_chem_ca_global_emis_multiplier
-  long_name = fraction of emissions to generate based on cellular automata
-  units = frac
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[ca_global_emis]
-  standard_name = flag_for_tracer_emissions_global_cellular_automata
-  long_name = switch for global ca applied to chemical tracer emissions
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
-  optional = F
 [do_sppt_emis]
   standard_name = flag_for_stochastic_emissions_perturbations
   long_name = flag for stochastic emissions perturbations
   units = flag
   dimensions = ()
   type = logical
+  intent = in
+  optional = F
+[sppt_wts]
+  standard_name = weights_for_stochastic_sppt_perturbation
+  long_name = weights for stochastic sppt perturbation
+  units = none
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
   intent = in
   optional = F
 [errmsg]

--- a/gsdchem/gsd_chem_anthropogenic_wrapper.meta
+++ b/gsdchem/gsd_chem_anthropogenic_wrapper.meta
@@ -220,6 +220,15 @@
   type = integer
   intent = in
   optional = F
+[pert_scale_anthro]
+  standard_name = anthropogenic_scaling_factor
+  long_name = Scaling factor for emissions of anthropogenic emissions
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [emis_amp_anthro]
   standard_name = anthropogenic_emissions_perturbation_amplitude
   long_name = multiplier of emissions random perturbation of anthropogenic emissions

--- a/gsdchem/gsd_chem_dust_wrapper.F90
+++ b/gsdchem/gsd_chem_dust_wrapper.F90
@@ -50,7 +50,7 @@ contains
                    ntdust1,ntdust2,ntdust3,ntdust4,ntdust5,ndust,               &
                    gq0,qgrs,duem,                                               &
                    chem_opt_in,dust_opt_in,dust_calcdrag_in,                    &
-                   dust_alpha_in,dust_gamma_in,                                 &
+                   dust_alpha_in,dust_gamma_in,pert_scale_dust,                 &
                    emis_amp_dust, emis_multiplier, do_sppt_emis, ca_global_emis,&
                    errmsg,errflg)
 
@@ -60,7 +60,7 @@ contains
     integer,        intent(in) :: im,kte,kme,ktau,nsoil
     integer,        intent(in) :: nseasalt,ntrac
     integer,        intent(in) :: ntdust1,ntdust2,ntdust3,ntdust4,ntdust5,ndust
-    real(kind_phys),intent(in) :: dt, emis_amp_dust
+    real(kind_phys),intent(in) :: dt, emis_amp_dust, pert_scale_dust
 
     logical,        intent(in) :: ca_global_emis, do_sppt_emis
     real, optional, intent(in) :: emis_multiplier(:)
@@ -137,7 +137,7 @@ contains
 
     if(do_sppt_emis .or. ca_global_emis) then
       do i = ims, im
-        random_factor(i,jms) = min(10.0,max(0.0,(emis_multiplier(i)-1.0)*emis_amp_dust + 1.0))
+        random_factor(i,jms) = min(10.0,max(0.0,((emis_multiplier(i)-1.0)*emis_amp_dust + 1.0)*pert_scale_dust))
       enddo
     else
       random_factor = 1.0

--- a/gsdchem/gsd_chem_dust_wrapper.F90
+++ b/gsdchem/gsd_chem_dust_wrapper.F90
@@ -51,8 +51,7 @@ contains
                    gq0,qgrs,duem,                                               &
                    chem_opt_in,dust_opt_in,dust_calcdrag_in,                    &
                    dust_alpha_in,dust_gamma_in,pert_scale_dust,                 &
-                   emis_amp_dust, emis_multiplier, do_sppt_emis, ca_global_emis,&
-                   errmsg,errflg)
+                   emis_amp_dust, do_sppt_emis, sppt_wts, errmsg,errflg)
 
     implicit none
 
@@ -62,8 +61,8 @@ contains
     integer,        intent(in) :: ntdust1,ntdust2,ntdust3,ntdust4,ntdust5,ndust
     real(kind_phys),intent(in) :: dt, emis_amp_dust, pert_scale_dust
 
-    logical,        intent(in) :: ca_global_emis, do_sppt_emis
-    real, optional, intent(in) :: emis_multiplier(:)
+    logical,        intent(in) :: do_sppt_emis
+    real(kind_phys), optional, intent(in) :: sppt_wts(:,:)
 
     integer, parameter :: ids=1,jds=1,jde=1, kds=1
     integer, parameter :: ims=1,jms=1,jme=1, kms=1
@@ -135,10 +134,8 @@ contains
     ite=im
     kde=kte
 
-    if(do_sppt_emis .or. ca_global_emis) then
-      do i = ims, im
-        random_factor(i,jms) = min(10.0,max(0.0,((emis_multiplier(i)-1.0)*emis_amp_dust + 1.0)*pert_scale_dust))
-      enddo
+    if(do_sppt_emis) then
+      random_factor(:,jms) = pert_scale_dust*max(min(1+(sppt_wts(:,kme/2)-1)*emis_amp_dust,2.0),0.0)
     else
       random_factor = 1.0
     endif

--- a/gsdchem/gsd_chem_dust_wrapper.meta
+++ b/gsdchem/gsd_chem_dust_wrapper.meta
@@ -457,29 +457,21 @@
   kind = kind_phys
   intent = in
   optional = F
-[emis_multiplier]
-  standard_name = gsd_chem_ca_global_emis_multiplier
-  long_name = fraction of emissions to generate based on cellular automata
-  units = frac
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[ca_global_emis]
-  standard_name = flag_for_tracer_emissions_global_cellular_automata
-  long_name = switch for global ca applied to chemical tracer emissions
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
-  optional = F
 [do_sppt_emis]
   standard_name = flag_for_stochastic_emissions_perturbations
   long_name = flag for stochastic emissions perturbations
   units = flag
   dimensions = ()
   type = logical
+  intent = in
+  optional = F
+[sppt_wts]
+  standard_name = weights_for_stochastic_sppt_perturbation
+  long_name = weights for stochastic sppt perturbation
+  units = none
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
   intent = in
   optional = F
 [errmsg]

--- a/gsdchem/gsd_chem_dust_wrapper.meta
+++ b/gsdchem/gsd_chem_dust_wrapper.meta
@@ -439,6 +439,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[pert_scale_dust]
+  standard_name = dust_emissions_scaling_factor
+  long_name = Scaling factor for emissions of dust emissions
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [emis_amp_dust]
   standard_name = dust_emissions_perturbation_amplitude
   long_name = multiplier of emissions random perturbation of dust emissions

--- a/gsdchem/gsd_chem_plume_wrapper.F90
+++ b/gsdchem/gsd_chem_plume_wrapper.F90
@@ -44,7 +44,7 @@ contains
                    pr3d, ph3d,phl3d, prl3d, tk3d, us3d, vs3d, spechum,           &
                    w,vegtype,fire_GBBEPx,fire_MODIS,                             &
                    ntrac,ntso2,ntpp25,ntbc1,ntoc1,ntpp10,                        &
-                   gq0,qgrs,ebu,abem,                                            &
+                   gq0,qgrs,ebu,abem,pert_scale_plume,                           &
                    biomass_burn_opt_in,plumerise_flag_in,plumerisefire_frq_in,   &
                    emis_amp_plume, emis_multiplier, do_sppt_emis,                &
                    ca_global_emis, errmsg,errflg)
@@ -54,7 +54,7 @@ contains
 
     integer,        intent(in) :: im,kte,kme,ktau
     integer,        intent(in) :: ntrac,ntso2,ntpp25,ntbc1,ntoc1,ntpp10
-    real(kind_phys),intent(in) :: dt, emis_amp_plume
+    real(kind_phys),intent(in) :: dt, emis_amp_plume, pert_scale_plume
 
     integer, parameter :: ids=1,jds=1,jde=1, kds=1
     integer, parameter :: ims=1,jms=1,jme=1, kms=1
@@ -177,7 +177,7 @@ contains
 
       if(plumerise_flag == FIRE_OPT_GBBEPx .and. (do_sppt_emis .or. ca_global_emis)) then
         do i = ims, im
-          random_factor(i) = min(10.0,max(0.0,(emis_multiplier(i)-1.0)*emis_amp_plume + 1.0))
+          random_factor(i) = min(10.0,max(0.0,((emis_multiplier(i)-1.0)*emis_amp_plume + 1.0)*pert_scale_plume))
         enddo
       endif
 

--- a/gsdchem/gsd_chem_plume_wrapper.F90
+++ b/gsdchem/gsd_chem_plume_wrapper.F90
@@ -46,8 +46,7 @@ contains
                    ntrac,ntso2,ntpp25,ntbc1,ntoc1,ntpp10,                        &
                    gq0,qgrs,ebu,abem,pert_scale_plume,                           &
                    biomass_burn_opt_in,plumerise_flag_in,plumerisefire_frq_in,   &
-                   emis_amp_plume, emis_multiplier, do_sppt_emis,                &
-                   ca_global_emis, errmsg,errflg)
+                   emis_amp_plume, do_sppt_emis, sppt_wts, errmsg,errflg)
 
     implicit none
 
@@ -60,8 +59,8 @@ contains
     integer, parameter :: ims=1,jms=1,jme=1, kms=1
     integer, parameter :: its=1,jts=1,jte=1, kts=1
 
-    logical,        intent(in) :: ca_global_emis, do_sppt_emis
-    real, optional, intent(in) :: emis_multiplier(:)
+    logical,        intent(in) :: do_sppt_emis
+    real(kind_phys), optional, intent(in) :: sppt_wts(:,:)
     integer, dimension(im), intent(in) :: vegtype    
     real(kind_phys), dimension(im,    5), intent(in) :: fire_GBBEPx
     real(kind_phys), dimension(im,   13), intent(in) :: fire_MODIS
@@ -175,10 +174,8 @@ contains
     if (biomass_burn_opt == BURN_OPT_ENABLE) then
       jp = jte
 
-      if(plumerise_flag == FIRE_OPT_GBBEPx .and. (do_sppt_emis .or. ca_global_emis)) then
-        do i = ims, im
-          random_factor(i) = min(10.0,max(0.0,((emis_multiplier(i)-1.0)*emis_amp_plume + 1.0)*pert_scale_plume))
-        enddo
+      if(plumerise_flag == FIRE_OPT_GBBEPx .and. do_sppt_emis) then
+        random_factor(:) = pert_scale_plume*max(min(1+(sppt_wts(:,kme/2)-1)*emis_amp_plume,2.0),0.0)
       endif
 
       factor3 = 0._kind_phys

--- a/gsdchem/gsd_chem_plume_wrapper.F90
+++ b/gsdchem/gsd_chem_plume_wrapper.F90
@@ -44,8 +44,8 @@ contains
                    pr3d, ph3d,phl3d, prl3d, tk3d, us3d, vs3d, spechum,           &
                    w,vegtype,fire_GBBEPx,fire_MODIS,                             &
                    ntrac,ntso2,ntpp25,ntbc1,ntoc1,ntpp10,                        &
-                   gq0,qgrs,ebu,abem,pert_scale_plume,                           &
-                   biomass_burn_opt_in,plumerise_flag_in,plumerisefire_frq_in,   &
+                   gq0,qgrs,ebu,abem,biomass_burn_opt_in,plumerise_flag_in,      &
+                   plumerisefire_frq_in,pert_scale_plume,                        &
                    emis_amp_plume, do_sppt_emis, sppt_wts, errmsg,errflg)
 
     implicit none

--- a/gsdchem/gsd_chem_plume_wrapper.meta
+++ b/gsdchem/gsd_chem_plume_wrapper.meta
@@ -289,29 +289,21 @@
   dimensions = ()
   type = real
   kind = kind_phys
-[emis_multiplier]
-  standard_name = gsd_chem_ca_global_emis_multiplier
-  long_name = fraction of emissions to generate based on cellular automata
-  units = frac
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[ca_global_emis]
-  standard_name = flag_for_tracer_emissions_global_cellular_automata
-  long_name = switch for global ca applied to chemical tracer emissions
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
-  optional = F
 [do_sppt_emis]
   standard_name = flag_for_stochastic_emissions_perturbations
   long_name = flag for stochastic emissions perturbations
   units = flag
   dimensions = ()
   type = logical
+  intent = in
+  optional = F
+[sppt_wts]
+  standard_name = weights_for_stochastic_sppt_perturbation
+  long_name = weights for stochastic sppt perturbation
+  units = none
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
   intent = in
   optional = F
 [errmsg]

--- a/gsdchem/gsd_chem_plume_wrapper.meta
+++ b/gsdchem/gsd_chem_plume_wrapper.meta
@@ -249,6 +249,15 @@
   kind = kind_phys
   intent = inout
   optional = F
+[pert_scale_plume]
+  standard_name = plume_emissions_scaling_factor
+  long_name = Scaling factor for emissions of plume rising
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [biomass_burn_opt_in]
   standard_name = gsd_chem_biomass_burn_opt
   long_name = gsd chem biomass burning option

--- a/gsdchem/gsd_chem_seas_wrapper.F90
+++ b/gsdchem/gsd_chem_seas_wrapper.F90
@@ -51,15 +51,14 @@ contains
 !!
 !>\section gsd_chem_seas_wrapper GSD Chemistry Scheme General Algorithm
 !> @{
-    subroutine gsd_chem_seas_wrapper_run(im, kte, kme, ktau, dt, garea,       &
-                   land, u10m, v10m, ustar, rlat, rlon, tskin,                &
-                   pr3d, ph3d,prl3d, tk3d, us3d, vs3d, spechum,               &
-                   nseasalt,ntrac,ntss1,ntss2,ntss3,ntss4,ntss5,              &
-                   gq0,qgrs,ssem,seas_opt_in, emis_amp_seas, emis_multiplier, &
+    subroutine gsd_chem_seas_wrapper_run(im, kte, kme, ktau, dt, garea,          &
+                   land, u10m, v10m, ustar, rlat, rlon, tskin,                   &
+                   pr3d, ph3d,prl3d, tk3d, us3d, vs3d, spechum,                  &
+                   nseasalt,ntrac,ntss1,ntss2,ntss3,ntss4,ntss5,pert_scale_seas, &
+                   gq0,qgrs,ssem,seas_opt_in, emis_amp_seas, emis_multiplier,    &
                    ca1, ca_global_emis, do_sppt_emis, sppt_wts, errmsg, errflg)
 
     implicit none
-
 
     integer,        intent(in) :: im,kte,kme,ktau
     integer,        intent(in) :: nseasalt,ntrac,ntss1,ntss2,ntss3,ntss4,ntss5
@@ -67,7 +66,7 @@ contains
 
     logical,        intent(in) :: ca_global_emis, do_sppt_emis
     real, optional, intent(inout) :: emis_multiplier(:)
-    real, intent(in)    :: ca1(im), emis_amp_seas
+    real, intent(in)    :: ca1(im), emis_amp_seas, pert_scale_seas
     real(kind_phys), optional, intent(in) :: sppt_wts(:,:)
 
 
@@ -142,7 +141,7 @@ contains
 
     if(do_sppt_emis .or. ca_global_emis) then
       do i=ims,im
-        random_factor(i,jms) = min(10.0,max(0.0,(emis_multiplier(i)-1.0)*emis_amp_seas + 1.0))
+        random_factor(i,jms) = min(10.0,max(0.0,((emis_multiplier(i)-1.0)*emis_amp_seas + 1.0)*pert_scale_seas))
       enddo
     endif
 

--- a/gsdchem/gsd_chem_seas_wrapper.F90
+++ b/gsdchem/gsd_chem_seas_wrapper.F90
@@ -42,8 +42,8 @@ contains
     subroutine gsd_chem_seas_wrapper_run(im, kte, kme, ktau, dt, garea,          &
                    land, u10m, v10m, ustar, rlat, rlon, tskin,                   &
                    pr3d, ph3d,prl3d, tk3d, us3d, vs3d, spechum,                  &
-                   nseasalt,ntrac,ntss1,ntss2,ntss3,ntss4,ntss5,pert_scale_seas, &
-                   gq0,qgrs,ssem,seas_opt_in, emis_amp_seas,                     &
+                   nseasalt,ntrac,ntss1,ntss2,ntss3,ntss4,ntss5,                 &
+                   gq0,qgrs,ssem,seas_opt_in, pert_scale_seas, emis_amp_seas,    &
                    do_sppt_emis, sppt_wts, errmsg, errflg)
 
     implicit none

--- a/gsdchem/gsd_chem_seas_wrapper.meta
+++ b/gsdchem/gsd_chem_seas_wrapper.meta
@@ -7,56 +7,6 @@
 [ccpp-arg-table]
   name = gsd_chem_seas_wrapper_init
   type = scheme
-[ca_global_emis]
-  standard_name = flag_for_tracer_emissions_global_cellular_automata
-  long_name = switch for global ca applied to chemical tracer emissions
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
-  optional = F
-[do_sppt_emis]
-  standard_name = flag_for_stochastic_emissions_perturbations
-  long_name = flag for stochastic emissions perturbations
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
-  optional = F
-[im]
-  standard_name = horizontal_dimension
-  long_name = horizontal dimension
-  units = count
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[emis_multiplier]
-  standard_name = gsd_chem_ca_global_emis_multiplier
-  long_name = fraction of emissions to generate based on cellular automata
-  units = frac
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[errmsg]
-  standard_name = ccpp_error_message
-  long_name = error message for error handling in CCPP
-  units = none
-  dimensions = ()
-  type = character
-  kind = len=*
-  intent = out
-  optional = F
-[errflg]
-  standard_name = ccpp_error_flag
-  long_name = error flag for error handling in CCPP
-  units = flag
-  dimensions = ()
-  type = integer
-  intent = out
-  optional = F
 
 ########################################################################
 [ccpp-arg-table]
@@ -349,32 +299,6 @@
   dimensions = ()
   type = real
   kind = kind_phys
-  intent = in
-  optional = F
-[emis_multiplier]
-  standard_name = gsd_chem_ca_global_emis_multiplier
-  long_name = fraction of emissions to generate based on cellular automata
-  units = frac
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-  intent = inout
-  optional = F
-[ca1]
-  standard_name = cellular_automata_global_pattern
-  long_name = cellular automata global pattern
-  units = flag
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[ca_global_emis]
-  standard_name = flag_for_tracer_emissions_global_cellular_automata
-  long_name = switch for global ca applied to chemical tracer emissions
-  units = flag
-  dimensions = ()
-  type = logical
   intent = in
   optional = F
 [do_sppt_emis]

--- a/gsdchem/gsd_chem_seas_wrapper.meta
+++ b/gsdchem/gsd_chem_seas_wrapper.meta
@@ -298,6 +298,15 @@
   type = integer
   intent = in
   optional = F
+[pert_scale_seas]
+  standard_name = sea_spray_emissions_scaling_factor
+  long_name = Scaling factor for emissions of sea spray
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [gq0]
   standard_name = tracer_concentration_updated_by_physics
   long_name = tracer concentration updated by physics


### PR DESCRIPTION
These changes introduce a scaling factor for emissions when stochastic perturbations are enabled. Also, they eliminate support for ca_global_chem. Removing that let us also remove the `emis_multiplier` array and code that initialized it.