### PR TITLE
Bugfixes for Shinhong and YSU 3d tendency arrays

### DIFF
--- a/physics/shinhongvdif.F90
+++ b/physics/shinhongvdif.F90
@@ -131,7 +131,7 @@
                                                                          ttnp
    real(kind=kind_phys),     dimension(im, km, ntrac )                                       , &
              intent(inout)   ::                                          qtnp
-   real(kind=kind_phys),     dimension(im,km)                                     , &
+   real(kind=kind_phys),     dimension(:,:)                                                  , &
              intent(inout)   :: du3dt_PBL, dv3dt_PBL, dt3dt_PBL, dq3dt_PBL, do3dt_PBL
 ! 2D in
    integer,  dimension(im)                                                   , &

--- a/physics/ysuvdif.F90
+++ b/physics/ysuvdif.F90
@@ -88,7 +88,7 @@
              intent(inout)   ::                                utnp,vtnp,ttnp
    real(kind=kind_phys),     dimension( im,km,ntrac )                             , &
              intent(inout)   ::                                          qtnp
-   real(kind=kind_phys),     dimension(im,km)                                     , &
+   real(kind=kind_phys),     dimension(:,:)                                       , &
              intent(inout)   :: du3dt_PBL, dv3dt_PBL, dt3dt_PBL, dq3dt_PBL, do3dt_PBL
 !
 !---------------------------------------------------------------------------------


### PR DESCRIPTION
Bugfixes in physics/shinhongvdif.F90 and physics/ysuvdif.F90: use assumed sizes for 3D tendency arrays, since these arrays are only allocated if `ldiag3d` is `.true.`. With this change, both schemes run with the GNU compiler (tested in REPRO mode).