### PR TITLE
Use the Flake model with RUC LSM in FV3_HRRR and FV3_GSD_v0 suites. Bug fixes for fractional grid.

### DIFF
--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -164,6 +164,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[landfrac]
+  standard_name = land_area_fraction
+  long_name = fraction of horizontal grid area occupied by land
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [q1]
   standard_name = water_vapor_specific_humidity_at_lowest_model_layer
   long_name = water vapor specific humidity at lowest model layer
@@ -844,7 +853,7 @@
   type = logical
   intent = in
   optional = F
-[lake]
+[use_lake]
   standard_name = flag_for_using_flake
   long_name = flag indicating lake points using flake model
   units = flag


### PR DESCRIPTION
1. Changes for fracional grid (frac_grid=.true.)
2. Replace logical variable for lakes from 'lake' to 'use_flake' in sfc_drv_ruc.F90. 
3. Added call to Flake to FV3_HRRR and FV3_GSD_v0 suites.
4. Added spp code from WRF version of RUC LSM in case it would be needed
for RRFS. So far it is not hooked up to SPP weights and not changing the results.

Associated PRs:

https://github.com/NOAA-GSL/fv3atm/pull/105
https://github.com/NOAA-GSL/ccpp-physics/pull/103
https://github.com/NOAA-GSL/ufs-weather-model/pull/99

See https://github.com/NOAA-GSL/ufs-weather-model/pull/99 for code review and testing