### PR TITLE
Updates to MYNN-EDMF

### DIFF
--- a/physics/module_MYNNPBL_wrapper.F90
+++ b/physics/module_MYNNPBL_wrapper.F90
@@ -223,7 +223,7 @@ SUBROUTINE mynnedmf_wrapper_run(        &
      &       spp_pbl=0,                                     &
      &       bl_mynn_mixscalars=1
       REAL, PARAMETER ::                                    &
-     &       closure=2.5   !2.5, 2.6 or 3.0
+     &       closure=2.6   !2.5, 2.6 or 3.0
       LOGICAL ::                                            &
      &       FLAG_QI, FLAG_QNI, FLAG_QC, FLAG_QNC,          &
      &       FLAG_QNWFA, FLAG_QNIFA

--- a/physics/module_bl_mynn.F90
+++ b/physics/module_bl_mynn.F90
@@ -3237,6 +3237,7 @@ CONTAINS
 
     ustdrag = MIN(ust*ust,0.99)/wspd  ! limit at ~ 20 m/s
     ustdiff = MIN(ust*ust,0.01)/wspd  ! limit at ~ 2 m/s
+    dth(kts:kte) = 0.0  ! must initialize for moisture_check routine
 
 !!============================================
 !! u


### PR DESCRIPTION
Many changes are wrapped into this particular PR, the most significant changes help to improve the conservation of heat and moisture. The following is a summary:

- Stability Functions: Currently staying with original forms but limiting Prandtl number to < 10.  This results in a small increase in wind shear in stable conditions
- Mixing Lengths: Tuning the BouLac length scale for better performance in the free atmosphere.
- Mass Flux: Added density dependence to mass-flux portion of the solver to better conserve heat, moisture and momentum
- Subgrid-Scale (SGS) Clouds: switch to use the new 2nd-order (q´2) stratus cloud PDF as default.
- Closure Level 2.6 is now the default. Prognoses TKE and q´2. This allows better performance of the new cloud PDF.
- Added a "Moisture_Check" routine to remove negative mixing ratios instead of simply zeroing-out negative mixing ratios.
- Theta Tendency Calculation: use updated qc and qi to convert θli to θ.
