### PR TITLE
Bug fixes in MYNN surface layer scheme. Also, added lat/log to RUC LSM for debugging.

### DIFF
--- a/physics/module_MYNNSFC_wrapper.F90
+++ b/physics/module_MYNNSFC_wrapper.F90
@@ -57,7 +57,7 @@
 !###===================================================================
 SUBROUTINE mynnsfc_wrapper_run(            &
      &  im,levs,                           &
-     &  itimestep,iter,                    &
+     &  itimestep,iter,flag_iter,          &
      &  flag_init,flag_restart,lsm,lsm_ruc,&
      &  sigmaf,vegtype,shdmax,ivegsrc,     &  !intent(in)
      &  z0pert,ztpert,                     &  !intent(in)
@@ -111,6 +111,15 @@ SUBROUTINE mynnsfc_wrapper_run(            &
 !     &                     EP_2   => con_eps
 
 !      USE module_sf_mynn, only : SFCLAY_mynn 
+!tgs - info on iterations: 
+!     flag_iter- logical, execution or not (im)
+!                when iter = 1, flag_iter = .true. for all grids   im   !
+!                when iter = 2, flag_iter = .true. when wind < 2   im   !
+!                for both land and ocean (when nstf_name1 > 0)     im   !
+!     flag_guess-logical, .true.=  guess step to get CD et al      im   !
+!                when iter = 1, flag_guess = .true. when wind < 2  im   !
+!                when iter = 2, flag_guess = .false. for all grids im   !
+
 
 !------------------------------------------------------------------- 
       implicit none
@@ -141,6 +150,7 @@ SUBROUTINE mynnsfc_wrapper_run(            &
 
       integer, intent(in) :: im, levs
       integer, intent(in) :: iter, itimestep, lsm, lsm_ruc
+      logical, dimension(:), intent(in) :: flag_iter
       logical, intent(in) :: flag_init,flag_restart,lprnt
       integer, intent(in) :: ivegsrc
       integer, intent(in) :: sfc_z0_type ! option for calculating surface roughness length over ocean
@@ -295,7 +305,7 @@ SUBROUTINE mynnsfc_wrapper_run(            &
     &        sigmaf=sigmaf,vegtype=vegtype,shdmax=shdmax,ivegsrc=ivegsrc,     & !intent(in)
     &        z0pert=z0pert,ztpert=ztpert,                                     & !intent(in)
     &        redrag=redrag,sfc_z0_type=sfc_z0_type,                           & !intent(in)
-             itimestep=itimestep,iter=iter,                                   &
+             itimestep=itimestep,iter=iter,flag_iter=flag_iter,               &
                          wet=wet,              dry=dry,              icy=icy, &  !intent(in)
              tskin_wat=tskin_wat,  tskin_lnd=tskin_lnd,  tskin_ice=tskin_ice, &  !intent(in)
              tsurf_wat=tsurf_wat,  tsurf_lnd=tsurf_lnd,  tsurf_ice=tsurf_ice, &  !intent(in)

--- a/physics/module_MYNNSFC_wrapper.F90
+++ b/physics/module_MYNNSFC_wrapper.F90
@@ -194,7 +194,7 @@ SUBROUTINE mynnsfc_wrapper_run(            &
       real, dimension(im) ::                                &
      &        hfx, znt, psim, psih,                         &
      &        chs, ck, cd, mavail, xland, GZ1OZ0,           &
-     &        cpm, qgh, qfx, qsfc_ruc, snowh_wat
+     &        cpm, qgh, qfx, snowh_wat
 
      real(kind=kind_phys), dimension(im,levs) ::            &
     &        pattern_spp_pbl, dz, th, qv
@@ -249,10 +249,9 @@ SUBROUTINE mynnsfc_wrapper_run(            &
       where (icy) znt_ice=znt_ice*0.01
 
       ! qsfc ruc
-      qsfc_ruc = 0.0
       if (lsm==lsm_ruc) then
-        where (dry) qsfc_ruc = qsfc_lnd_ruc
-        where (icy) qsfc_ruc = qsfc_ice_ruc
+        where (dry) qsfc_lnd = qsfc_lnd_ruc/(1.+qsfc_lnd_ruc) ! spec. hum
+        where (icy) qsfc_ice = qsfc_ice_ruc/(1.+qsfc_ice_ruc) ! spec. hum.
       end if
 
 !      if (lprnt) then
@@ -291,7 +290,7 @@ SUBROUTINE mynnsfc_wrapper_run(            &
              CP=cp,G=g,ROVCP=rcp,R=r_d,XLV=xlv,                               &
              SVP1=svp1,SVP2=svp2,SVP3=svp3,SVPT0=svpt0,                       &
              EP1=ep_1,EP2=ep_2,KARMAN=karman,                                 &
-             ISFFLX=isfflx,isftcflx=isftcflx,LSM=lsm,                         &
+             ISFFLX=isfflx,isftcflx=isftcflx,LSM=lsm,LSM_RUC=lsm_ruc,         &
              iz0tlnd=iz0tlnd,psi_opt=psi_opt,                                 &
     &        sigmaf=sigmaf,vegtype=vegtype,shdmax=shdmax,ivegsrc=ivegsrc,     & !intent(in)
     &        z0pert=z0pert,ztpert=ztpert,                                     & !intent(in)
@@ -318,7 +317,7 @@ SUBROUTINE mynnsfc_wrapper_run(            &
              ZNT=znt,USTM=ustm,ZOL=zol,MOL=mol,RMOL=rmol,                     &
              psim=psim,psih=psih,                                             &
              HFLX=hflx,HFX=hfx,QFLX=qflx,QFX=qfx,LH=lh,FLHC=flhc,FLQC=flqc,   &
-             QGH=qgh,QSFC=qsfc,QSFC_RUC=qsfc_ruc,                             &
+             QGH=qgh,QSFC=qsfc,   &
              U10=u10,V10=v10,TH2=th2,T2=t2,Q2=q2,                             &
              GZ1OZ0=GZ1OZ0,WSPD=wspd,wstar=wstar,                             &
              spp_pbl=spp_pbl,pattern_spp_pbl=pattern_spp_pbl,                 &

--- a/physics/module_MYNNSFC_wrapper.meta
+++ b/physics/module_MYNNSFC_wrapper.meta
@@ -69,6 +69,14 @@
   type = integer
   intent = in
   optional = F
+[flag_iter]
+  standard_name = flag_for_iteration
+  long_name = flag for iteration
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
+  intent = in
+  optional = F
 [flag_init]
   standard_name = flag_for_first_timestep
   long_name = flag signaling first time step for time integration loop

--- a/physics/module_sf_mynn.F90
+++ b/physics/module_sf_mynn.F90
@@ -725,7 +725,7 @@ CONTAINS
         DO I=its,ite
            write(0,*)"=== important input to mynnsfclayer, i:", i
            IF (dry(i)) THEN
-             write(0,*)"dry=",dry(i)," =",pblh(i)," tsk=", tskin_lnd(i),&
+             write(0,*)"dry=",dry(i)," pblh=",pblh(i)," tsk=", tskin_lnd(i),&
              " tsurf=", tsurf_lnd(i)," qsfc=", qsfc_lnd(i)," znt=", znt_lnd(i),&
              " ust=", ust_lnd(i)," snowh=", snowh_lnd(i)," psfcpa=",PSFCPA(i),  &
              " dz=",dz8w1d(i)," qflx=",qflx(i)," hflx=",hflx(i)," hpbl=",pblh(i)

--- a/physics/module_sf_mynn.F90
+++ b/physics/module_sf_mynn.F90
@@ -131,7 +131,8 @@ CONTAINS
               PSFCPA,PBLH,MAVAIL,XLAND,DX,           & !in
               CP,G,ROVCP,R,XLV,                      & !in
               SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,   & !in
-              ISFFLX,isftcflx,lsm,iz0tlnd,psi_opt,   & !in
+              ISFFLX,isftcflx,lsm,lsm_ruc,           & !in
+              iz0tlnd,psi_opt,                       & !in
      &        sigmaf,vegtype,shdmax,ivegsrc,         & !intent(in)
      &        z0pert,ztpert,                         & !intent(in)
      &        redrag,sfc_z0_type,                    & !intent(in)
@@ -157,7 +158,7 @@ CONTAINS
               ZNT,USTM,ZOL,MOL,RMOL,                 &
               PSIM,PSIH,                             &
               HFLX,HFX,QFLX,QFX,LH,FLHC,FLQC,        &
-              QGH,QSFC,QSFC_RUC,                     &
+              QGH,QSFC,                              &
               U10,V10,TH2,T2,Q2,                     &
               GZ1OZ0,WSPD,WSTAR,                     &
               spp_pbl,pattern_spp_pbl,               &
@@ -268,7 +269,7 @@ CONTAINS
       REAL,     INTENT(IN)   ::        EP1,EP2,KARMAN
       REAL,     INTENT(IN)   ::        CP,G,ROVCP,R,XLV !,DX
 !NAMELIST/CONFIGURATION OPTIONS:
-      INTEGER,  INTENT(IN)   ::        ISFFLX, LSM
+      INTEGER,  INTENT(IN)   ::        ISFFLX, LSM, LSM_RUC
       INTEGER,  OPTIONAL,  INTENT(IN)   :: ISFTCFLX, IZ0TLND
       INTEGER,  OPTIONAL,  INTENT(IN)   :: spp_pbl, psi_opt
       integer, intent(in) :: ivegsrc
@@ -334,8 +335,7 @@ CONTAINS
       REAL, DIMENSION( ims:ime ), INTENT(IN)    ::                 &
      &                    tskin_wat, tskin_lnd, tskin_ice,         &
      &                    tsurf_wat, tsurf_lnd, tsurf_ice,         &
-     &                    snowh_wat, snowh_lnd, snowh_ice,         &
-     &                    qsfc_ruc
+     &                    snowh_wat, snowh_lnd, snowh_ice
 
       REAL, DIMENSION( ims:ime), INTENT(INOUT) ::                  &
      &                      ZNT_wat,   ZNT_lnd,   ZNT_ice,         &
@@ -410,22 +410,22 @@ CONTAINS
             UST_LND(i)=MAX(0.04*SQRT(U1D(i)*U1D(i) + V1D(i)*V1D(i)),0.001)
             UST_ICE(i)=MAX(0.04*SQRT(U1D(i)*U1D(i) + V1D(i)*V1D(i)),0.001)
             MOL(i)=0.0
-            QSFC(i)=QV3D(i,kts)/(1.+QV3D(i,kts))
-            QSFC_WAT(i)=QSFC(i)
-            QSFC_LND(i)=QSFC(i)
-            QSFC_ICE(i)=QSFC(i)
             qstar(i)=0.0
             QFX(i)=0.
             HFX(i)=0.
             QFLX(i)=0.
             HFLX(i)=0.
+            if ( LSM == LSM_RUC ) then
+            !- qsfc_lnd and qsfc_ice are already available
+               QSFC(i)=QV3D(i,kts)/(1.+QV3D(i,kts))
+               QSFC_WAT(i)=QSFC(i)
+            else
+               QSFC(i)=QV3D(i,kts)/(1.+QV3D(i,kts))
+               QSFC_WAT(i)=QSFC(i)
+               QSFC_LND(i)=QSFC(i)
+               QSFC_ICE(i)=QSFC(i)
+            endif ! lsm==lsm_ruc
          ENDDO
-      ELSE
-         IF (LSM == 3) THEN
-            DO i=its,ite
-               QSFC_LND(i)=QSFC_RUC(i)
-            ENDDO
-         ENDIF
       ENDIF
 
       CALL SFCLAY1D_mynn(                                       &
@@ -438,7 +438,7 @@ CONTAINS
            sigmaf,vegtype,shdmax,ivegsrc,                       &  !intent(in)
            z0pert,ztpert,                                       &  !intent(in)
            redrag,sfc_z0_type,                                  &  !intent(in)
-           itimestep,iter,                                      &
+           itimestep,iter,lsm,lsm_ruc,                          &
                   wet,          dry,          icy,              &  !intent(in)
             tskin_wat,    tskin_lnd,    tskin_ice,              &  !intent(in)
             tsurf_wat,    tsurf_lnd,    tsurf_ice,              &  !intent(in)
@@ -485,7 +485,7 @@ CONTAINS
              sigmaf,vegtype,shdmax,ivegsrc,                       &  !intent(in)
              z0pert,ztpert,                                       &  !intent(in)
              redrag,sfc_z0_type,                                  &  !intent(in)
-             itimestep,iter,                                      &
+             itimestep,iter,lsm,lsm_ruc,                          &
                     wet,          dry,          icy,              &  !intent(in)
               tskin_wat,    tskin_lnd,    tskin_ice,              &  !intent(in)
               tsurf_wat,    tsurf_lnd,    tsurf_ice,              &  !intent(in)
@@ -524,7 +524,7 @@ CONTAINS
       INTEGER,  INTENT(IN) ::        ids,ide, jds,jde, kds,kde, &
                                      ims,ime, jms,jme, kms,kme, &
                                      its,ite, jts,jte, kts,kte, &
-                                     J, itimestep, iter
+                                     J, itimestep, iter, lsm, lsm_ruc
 
       REAL,     PARAMETER  :: XKA=2.4E-5   !molecular diffusivity
       REAL,     PARAMETER  :: PRT=1.       !prandlt number
@@ -659,12 +659,73 @@ CONTAINS
       REAL    ::  restar,VISC,DQG,OLDUST,OLDTST
 
 !-------------------------------------------------------------------
+      DO I=its,ite
+
+         IF (ITIMESTEP == 1) THEN
+         !initialize surface specific humidity and mixing ratios for land, ice and water
+            IF (wet(i)) THEN
+               IF (TSK_wat(I) .LT. 273.15) THEN
+                  !SATURATION VAPOR PRESSURE WRT ICE (SVP1=.6112; 10*mb)
+                  E1=SVP1*EXP(4648*(1./273.15 - 1./TSK_wat(I)) - &
+                    & 11.64*LOG(273.15/TSK_wat(I)) + 0.02265*(273.15 - TSK_wat(I)))
+               ELSE
+                  !SATURATION VAPOR PRESSURE WRT WATER (Bolton 1980)
+                  E1=SVP1*EXP(SVP2*(TSK_wat(I)-SVPT0)/(TSK_wat(i)-SVP3))
+               ENDIF
+               QSFC_wat(I)=EP2*E1/(PSFC(I)-ep_3*E1)             !specific humidity    
+               QSFCMR_wat(I)=EP2*E1/(PSFC(I)-E1)                !mixing ratio 
+            ENDIF
+            IF (dry(i)) THEN
+              if( lsm == lsm_ruc) then
+                QSFCMR_lnd(I)=QSFC_lnd(I)/(1.-QSFC_lnd(I))       !mixing ratio 
+              else
+               TABS = 0.5*(TSK_lnd(I) + T1D(I))
+               IF (TABS .LT. 273.15) THEN
+                  !SATURATION VAPOR PRESSURE WRT ICE (SVP1=.6112; 10*mb)
+                  E1=SVP1*EXP(4648*(1./273.15 - 1./TABS) - &
+                    & 11.64*LOG(273.15/TABS) + 0.02265*(273.15 - TABS))
+               ELSE
+                  !SATURATION VAPOR PRESSURE WRT WATER (Bolton 1980)
+                  E1=SVP1*EXP(SVP2*(TABS-SVPT0)/(TABS-SVP3))
+               ENDIF
+                 QSFC_lnd(I)=EP2*E1/(PSFC(I)-ep_3*E1)             !specific humidity
+                 QSFC_lnd(I)=0.5*(QSFC_lnd(I) + QSFC(I))
+                 QSFCMR_lnd(I)=QSFC_lnd(I)/(1.-QSFC_lnd(I))       !mixing ratio
+              endif ! lsm
+            ENDIF
+            IF (icy(i)) THEN
+              if( lsm == lsm_ruc) then
+                QSFCMR_ice(I)=QSFC_ice(I)/(1.-QSFC_ice(I))       !mixing ratio 
+              else
+               IF (TSK_ice(I) .LT. 273.15) THEN
+                  !SATURATION VAPOR PRESSURE WRT ICE (SVP1=.6112; 10*mb)
+                  E1=SVP1*EXP(4648*(1./273.15 - 1./TSK_ice(I)) - &
+                    & 11.64*LOG(273.15/TSK_ice(I)) + 0.02265*(273.15 - TSK_ice(I)))
+               ELSE
+                  !SATURATION VAPOR PRESSURE WRT WATER (Bolton 1980)
+                  E1=SVP1*EXP(SVP2*(TSK_ice(I)-SVPT0)/(TSK_ice(i)-SVP3))
+               ENDIF
+                 QSFC_ice(I)=EP2*E1/(PSFC(I)-ep_3*E1)             !specific humidity
+                 QSFCMR_ice(I)=EP2*E1/(PSFC(I)-E1)                !mixing ratio
+              endif ! lsm
+            ENDIF
+
+         ELSE
+
+            ! Use what comes out of the LSM, NST, and CICE
+            IF (wet(i)) QSFCMR_wat(I)=QSFC_wat(I)/(1.-QSFC_wat(I))
+            IF (dry(i)) QSFCMR_lnd(I)=QSFC_lnd(I)/(1.-QSFC_lnd(I))
+            IF (icy(i)) QSFCMR_ice(I)=QSFC_ice(I)/(1.-QSFC_ice(I))
+
+         ENDIF
+      ENDDO
+
       IF (debug_code >= 1) THEN
         write(0,*)"ITIMESTEP=",ITIMESTEP," iter=",iter
         DO I=its,ite
            write(0,*)"=== important input to mynnsfclayer, i:", i
            IF (dry(i)) THEN
-             write(0,*)"dry=",dry(i)," pblh=",pblh(i)," tsk=", tskin_lnd(i),&
+             write(0,*)"dry=",dry(i)," =",pblh(i)," tsk=", tskin_lnd(i),&
              " tsurf=", tsurf_lnd(i)," qsfc=", qsfc_lnd(i)," znt=", znt_lnd(i),&
              " ust=", ust_lnd(i)," snowh=", snowh_lnd(i)," psfcpa=",PSFCPA(i),  &
              " dz=",dz8w1d(i)," qflx=",qflx(i)," hflx=",hflx(i)," hpbl=",pblh(i)
@@ -687,26 +748,33 @@ CONTAINS
       DO I=its,ite
          ! PSFC ( in cmb) is used later in saturation checks
          PSFC(I)=PSFCPA(I)/1000.
-         ! DEFINE SKIN TEMPERATURES FOR LAND/WATER/ICE
-         TSK_lnd(I) = 0.5 * (tsurf_lnd(i)+tskin_lnd(i))
-         TSK_ice(I) = 0.5 * (tsurf_ice(i)+tskin_ice(i))
-         TSK_wat(I) = 0.5 * (tsurf_wat(i)+tskin_wat(i))
          QVSH(I)=QV1D(I)/(1.+QV1D(I))        !CONVERT TO SPEC HUM (kg/kg)
          THCON(I)=(100000./PSFCPA(I))**ROVCP
-      ENDDO
-
-      DO I=its,ite
-         ! CONVERT SKIN TEMPERATURES TO POTENTIAL TEMPERATURE: 
-         THSK_lnd(I) = TSK_lnd(I)*THCON(I)   !(K)
-         THSK_ice(I) = TSK_ice(I)*THCON(I)   !(K)
-         THSK_wat(I) = TSK_wat(I)*THCON(I)   !(K)
-      ENDDO
-
-      DO I=its,ite
-         ! CONVERT SKIN POTENTIAL TEMPERATURES TO VIRTUAL POTENTIAL TEMPERATURE:
-         THVSK_lnd(I) = THSK_lnd(I)*(1.+EP1*QVSH(I))   !(K)
-         THVSK_ice(I) = THSK_ice(I)*(1.+EP1*QVSH(I))   !(K)
-         THVSK_wat(I) = THSK_wat(I)*(1.+EP1*QVSH(I))   !(K)
+         ! DEFINE SKIN TEMPERATURES FOR LAND/WATER/ICE
+         if(dry(i)) then
+           TSK_lnd(I) = 0.5 * (tsurf_lnd(i)+tskin_lnd(i))
+           ! CONVERT SKIN TEMPERATURES TO POTENTIAL TEMPERATURE: 
+           THSK_lnd(I) = TSK_lnd(I)*THCON(I)   !(K)
+           THVSK_lnd(I) = THSK_lnd(I)*(1.+EP1*qsfc_lnd(I))
+           if(THVSK_lnd(I) < 170. .or. THVSK_lnd(I) > 350.) &
+           print *,'THVSK_lnd(I)',i,THVSK_lnd(I),THSK_lnd(i),tsurf_lnd(i),tskin_lnd(i),qsfc_lnd(i)
+         endif
+         if(icy(i)) then
+           TSK_ice(I) = 0.5 * (tsurf_ice(i)+tskin_ice(i))
+           ! CONVERT SKIN TEMPERATURES TO POTENTIAL TEMPERATURE: 
+           THSK_ice(I) = TSK_ice(I)*THCON(I)   !(K)
+           THVSK_ice(I) = THSK_ice(I)*(1.+EP1*qsfc_ice(I))   !(K)
+           if(THVSK_ice(I) < 170. .or. THVSK_ice(I) > 350.) &
+           print *,'THVSK_ice(I)',i,THVSK_ice(I),THSK_ice(i),tsurf_ice(i),tskin_ice(i),qsfc_ice(i)
+         endif
+         if(wet(i)) then
+           TSK_wat(I) = 0.5 * (tsurf_wat(i)+tskin_wat(i))
+           ! CONVERT SKIN TEMPERATURES TO POTENTIAL TEMPERATURE: 
+           THSK_wat(I) = TSK_wat(I)*THCON(I)   !(K)
+           THVSK_wat(I) = THSK_wat(I)*(1.+EP1*QVSH(I))   !(K)
+           if(THVSK_wat(I) < 170. .or. THVSK_wat(I) > 350.) &
+           print *,'THVSK_wat(I)',i,THVSK_wat(I),THSK_wat(i),tsurf_wat(i),tskin_wat(i),qsfc_wat(i)
+         endif
       ENDDO
 
       DO I=its,ite
@@ -728,6 +796,7 @@ CONTAINS
          GOVRTH(I)=G/TH1D(I)
       ENDDO
 
+      !tgs - should QFX and HFX be separate for land, ice and water?
       DO I=its,ite
          QFX(i)=QFLX(i)*RHO1D(I)
          HFX(i)=HFLX(i)*RHO1D(I)*cp
@@ -747,56 +816,6 @@ CONTAINS
       ENDIF
 
       DO I=its,ite
-
-         IF (ITIMESTEP == 1) THEN
-            IF (wet(i)) THEN
-               IF (TSK_wat(I) .LT. 273.15) THEN
-                  !SATURATION VAPOR PRESSURE WRT ICE (SVP1=.6112; 10*mb)
-                  E1=SVP1*EXP(4648*(1./273.15 - 1./TSK_wat(I)) - &
-                    & 11.64*LOG(273.15/TSK_wat(I)) + 0.02265*(273.15 - TSK_wat(I)))
-               ELSE
-                  !SATURATION VAPOR PRESSURE WRT WATER (Bolton 1980)
-                  E1=SVP1*EXP(SVP2*(TSK_wat(I)-SVPT0)/(TSK_wat(i)-SVP3))
-               ENDIF
-               QSFC_wat(I)=EP2*E1/(PSFC(I)-ep_3*E1)             !specific humidity    
-               QSFCMR_wat(I)=EP2*E1/(PSFC(I)-E1)                !mixing ratio 
-            ENDIF
-            IF (dry(i)) THEN
-               TABS = 0.5*(TSK_lnd(I) + T1D(I))
-               IF (TABS .LT. 273.15) THEN
-                  !SATURATION VAPOR PRESSURE WRT ICE (SVP1=.6112; 10*mb)
-                  E1=SVP1*EXP(4648*(1./273.15 - 1./TABS) - &
-                    & 11.64*LOG(273.15/TABS) + 0.02265*(273.15 - TABS))
-               ELSE
-                  !SATURATION VAPOR PRESSURE WRT WATER (Bolton 1980)
-                  E1=SVP1*EXP(SVP2*(TABS-SVPT0)/(TABS-SVP3))
-               ENDIF
-               QSFC_lnd(I)=EP2*E1/(PSFC(I)-ep_3*E1)             !specific humidity
-               QSFC_lnd(I)=0.5*(QSFC_lnd(I) + QSFC(I))
-               QSFCMR_lnd(I)=QSFC_lnd(I)/(1.-QSFC_lnd(I))       !mixing ratio
-            ENDIF
-            IF (icy(i)) THEN
-               IF (TSK_ice(I) .LT. 273.15) THEN
-                  !SATURATION VAPOR PRESSURE WRT ICE (SVP1=.6112; 10*mb)
-                  E1=SVP1*EXP(4648*(1./273.15 - 1./TSK_ice(I)) - &
-                    & 11.64*LOG(273.15/TSK_ice(I)) + 0.02265*(273.15 - TSK_ice(I)))
-               ELSE
-                  !SATURATION VAPOR PRESSURE WRT WATER (Bolton 1980)
-                  E1=SVP1*EXP(SVP2*(TSK_ice(I)-SVPT0)/(TSK_ice(i)-SVP3))
-               ENDIF
-               QSFC_ice(I)=EP2*E1/(PSFC(I)-ep_3*E1)             !specific humidity
-               QSFCMR_ice(I)=EP2*E1/(PSFC(I)-E1)                !mixing ratio
-            ENDIF
-
-         ELSE
-
-            ! Use what comes out of the LSM, NST, and CICE
-            IF (wet(i)) QSFCMR_wat(I)=QSFC_wat(I)/(1.-QSFC_wat(I))
-            IF (dry(i)) QSFCMR_lnd(I)=QSFC_lnd(I)/(1.-QSFC_lnd(I))
-            IF (icy(i)) QSFCMR_ice(I)=QSFC_ice(I)/(1.-QSFC_ice(I))
-
-         ENDIF
-
          ! QGH CHANGED TO USE LOWEST-LEVEL AIR TEMP
          ! Q2SAT = QGH IN LSM
          IF (T1D(I) .LT. 273.15) THEN
@@ -1194,6 +1213,7 @@ CONTAINS
     ENDIF  !end ice point
 
     !Capture a representative ZNT
+    !tgs - should this be changed for fractional grid or fractional sea ice?
     IF (dry(i)) THEN
        ZNT(i)=ZNTstoch_lnd(I)
     ELSEIF (wet(i)) THEN
@@ -1616,6 +1636,7 @@ CONTAINS
 
        ! Compute u* without vconv for use in HFX calc when isftcflx > 0           
        WSPDI(I)=MAX(SQRT(U1D(I)*U1D(I)+V1D(I)*V1D(I)), wmin)
+       !tgs - should USTM be separater for dry, icy, wet?
        USTM(I)=0.5*USTM(I)+0.5*KARMAN*WSPDI(I)/PSIX_wat(I)
 
        ! for possible future changes in sea-ice fraction from 0 to >0:
@@ -1638,6 +1659,7 @@ CONTAINS
        stress_lnd(i)=ust_lnd(i)**2
 
        !set ustm = ust over land.
+       !tgs - should USTM be separater for dry, icy, wet?
        USTM(I)=UST_lnd(I)
     ENDIF ! end water points
 
@@ -1651,9 +1673,11 @@ CONTAINS
        stress_ice(i)=ust_ice(i)**2
 
        !Set ustm = ust over ice.
+       !tgs - should USTM be separate for for dry, icy, wet?
        USTM(I)=UST_ice(I)
 
        ! for possible future changes in sea-ice fraction from 1 to <1:
+       !tgs - sea ice can be <1 now
        if (.not. wet(i)) ust_wat(i)=ust_ice(i)
     ENDIF ! end ice points
 
@@ -1662,6 +1686,7 @@ CONTAINS
     !----AND COMPUTE THE MOISTURE SCALE (or q*)
     !----------------------------------------------------
 
+    !tgs - should we have MOL and qstar separate for dry, icy and wet?
     IF (wet(I)) THEN
        DTG=THV1D(I)-THVSK_wat(I)
        OLDTST=MOL(I)
@@ -1750,6 +1775,7 @@ CONTAINS
          ! CALCULATE THE EXCHANGE COEFFICIENTS FOR HEAT (FLHC)
          ! AND MOISTURE (FLQC)
          !------------------------------------------
+         !tgs - should FLQC, FLHC be separate for dry, icy and wet?
          FLQC(I)=RHO1D(I)*MAVAIL(I)*UST_lnd(I)*KARMAN/PSIQ_lnd(i)
          FLHC(I)=RHO1D(I)*CPM(I)*UST_lnd(I)*KARMAN/PSIT_lnd(I)
 
@@ -1757,8 +1783,8 @@ CONTAINS
             !----------------------------------
             ! COMPUTE SURFACE MOISTURE FLUX:
             !----------------------------------
-            !QFX(I)=FLQC(I)*(QSFCMR_lnd(I)-QV1D(I))
-            QFX(I)=FLQC(I)*(QSFC_lnd(I)-QV1D(I))
+            QFX(I)=FLQC(I)*(QSFCMR_lnd(I)-QV1D(I))
+            !QFX(I)=FLQC(I)*(QSFC_lnd(I)-QV1D(I))
             QFX(I)=MAX(QFX(I),-0.02)      !allows small neg QFX
             LH(i)=XLV*QFX(i)
             ! BWG, 2020-06-17: Mod next 2 lines for fractional
@@ -1778,6 +1804,8 @@ CONTAINS
          !TRANSFER COEFF FOR SOME LSMs:
          !CHS(I)=UST(I)*KARMAN/(ALOG(KARMAN*UST(I)*ZA(I) &
          !       /XKA+ZA(I)/ZL)-PSIH(I))
+
+         !tgs - should QSFC, CHS, CHS2 and CQS2 be separate for dry, icy and wet?
          CHS(I)=UST_lnd(I)*KARMAN/PSIT_lnd(I)
 
          !THESE ARE USED FOR 2-M DIAGNOSTICS ONLY
@@ -1799,8 +1827,8 @@ CONTAINS
             !----------------------------------
             ! COMPUTE SURFACE MOISTURE FLUX:
             !----------------------------------
-            !QFX(I)=FLQC(I)*(QSFCMR_wat(I)-QV1D(I))
-            QFX(I)=FLQC(I)*(QSFC_wat(I)-QV1D(I))
+            QFX(I)=FLQC(I)*(QSFCMR_wat(I)-QV1D(I))
+            !QFX(I)=FLQC(I)*(QSFC_wat(I)-QV1D(I))
             QFX(I)=MAX(QFX(I),-0.02)      !allows small neg QFX
             LH(I)=XLV*QFX(I)
             ! BWG, 2020-06-17: Mod next 2 lines for fractional
@@ -1846,8 +1874,8 @@ CONTAINS
             !----------------------------------
             ! COMPUTE SURFACE MOISTURE FLUX:   
             !----------------------------------
-            !QFX(I)=FLQC(I)*(QSFCMR_ice(I)-QV1D(I))
-            QFX(I)=FLQC(I)*(QSFC_ice(I)-QV1D(I))
+            QFX(I)=FLQC(I)*(QSFCMR_ice(I)-QV1D(I))
+            !QFX(I)=FLQC(I)*(QSFC_ice(I)-QV1D(I))
             QFX(I)=MAX(QFX(I),-0.02)      !allows small neg QFX
             LH(I)=XLF*QFX(I)
             ! BWG, 2020-06-17: Mod next 2 lines for fractional

--- a/physics/module_sf_mynn.F90
+++ b/physics/module_sf_mynn.F90
@@ -661,6 +661,9 @@ CONTAINS
 !-------------------------------------------------------------------
       DO I=its,ite
 
+         ! PSFC ( in cmb) is used later in saturation checks
+         PSFC(I)=PSFCPA(I)/1000.
+
          IF (ITIMESTEP == 1) THEN
          !initialize surface specific humidity and mixing ratios for land, ice and water
             IF (wet(i)) THEN
@@ -870,6 +873,9 @@ CONTAINS
             ! subgrid-scale velocity (VSGD) following Beljaars (1995, QJRMS) 
             ! and Mahrt and Sun (1995, MWR), respectively
             !-------------------------------------------------------
+            !tgs - the line below could be used when hflx_wat,qflx_wat are moved from
+            !      Interstitial to Sfcprop
+            !fluxc = max(hflx_wat(i) + ep1*THVSK_wat(I)*qflx_wat(i),0.)
             fluxc = max(hfx(i)/RHO1D(i)/cp                    &
             &    + ep1*THVSK_wat(I)*qfx(i)/RHO1D(i),0.)
             !WSTAR(I) = vconvc*(g/TSK(i)*pblh(i)*fluxc)**onethird
@@ -902,6 +908,9 @@ CONTAINS
             ! subgrid-scale velocity (VSGD) following Beljaars (1995, QJRMS)
             ! and Mahrt and Sun (1995, MWR), respectively
             !-------------------------------------------------------
+            !tgs - the line below could be used when hflx_lnd,qflx_wat are moved from
+            !      Interstitial to Sfcprop
+            !fluxc = max(hflx_lnd(i) + ep1*THVSK_lnd(I)*qflx_lnd(i),0.)
             fluxc = max(hfx(i)/RHO1D(i)/cp                    &
             &    + ep1*THVSK_lnd(I)*qfx(i)/RHO1D(i),0.)
             ! WSTAR(I) = vconvc*(g/TSK(i)*pblh(i)*fluxc)**onethird
@@ -942,6 +951,9 @@ CONTAINS
             ! subgrid-scale velocity (VSGD) following Beljaars (1995, QJRMS)
             ! and Mahrt and Sun (1995, MWR), respectively
             !-------------------------------------------------------
+            !tgs - the line below could be used when hflx_ice,qflx_ice are moved from
+            !      Interstitial to Sfcprop
+            !fluxc = max(hflx_ice(i) + ep1*THVSK_ice(I)*qflx_ice(i)/RHO1D(i),0.)
             fluxc = max(hfx(i)/RHO1D(i)/cp                    &
             &    + ep1*THVSK_ice(I)*qfx(i)/RHO1D(i),0.)
             ! WSTAR(I) = vconvc*(g/TSK(i)*pblh(i)*fluxc)**onethird
@@ -1175,6 +1187,15 @@ CONTAINS
                          UST_lnd(I),KARMAN,1.0,0,spp_pbl,rstoch1D(i))
           ENDIF
        ENDIF
+       IF (ZNTstoch_lnd(i) < 1E-8 .OR. Zt_lnd(i) < 1E-10) THEN 
+         write(0,*)"===(land) capture bad input in mynn sfc layer, i=:",i
+         write(0,*)" ZNT=", ZNTstoch_lnd(i)," ZT=",Zt_lnd(i) 
+         write(0,*)" tsk=", tskin_lnd(i)," restar=",restar,&
+         " tsurf=", tsurf_lnd(i)," qsfc=", qsfc_lnd(i)," znt=", znt_lnd(i),&
+         " ust=", ust_lnd(i)," snowh=", snowh_lnd(i),"psfcpa=",PSFCPA(i), &
+         " dz=",dz8w1d(i)," qflx=",qflx_lnd(i)," hflx=",hflx_lnd(i)," hpbl=",pblh(i)
+       ENDIF
+
 
        GZ1OZ0_lnd(I)= LOG((ZA(I)+ZNTstoch_lnd(I))/ZNTstoch_lnd(I))
        GZ1OZt_lnd(I)= LOG((ZA(I)+ZNTstoch_lnd(i))/ZT_lnd(i))

--- a/physics/module_sf_mynn.F90
+++ b/physics/module_sf_mynn.F90
@@ -664,6 +664,7 @@ CONTAINS
          IF (ITIMESTEP == 1) THEN
          !initialize surface specific humidity and mixing ratios for land, ice and water
             IF (wet(i)) THEN
+               TSK_wat(I) = 0.5 * (tsurf_wat(i)+tskin_wat(i))
                IF (TSK_wat(I) .LT. 273.15) THEN
                   !SATURATION VAPOR PRESSURE WRT ICE (SVP1=.6112; 10*mb)
                   E1=SVP1*EXP(4648*(1./273.15 - 1./TSK_wat(I)) - &
@@ -676,6 +677,7 @@ CONTAINS
                QSFCMR_wat(I)=EP2*E1/(PSFC(I)-E1)                !mixing ratio 
             ENDIF
             IF (dry(i)) THEN
+              TSK_lnd(I) = 0.5 * (tsurf_lnd(i)+tskin_lnd(i))
               if( lsm == lsm_ruc) then
                 QSFCMR_lnd(I)=QSFC_lnd(I)/(1.-QSFC_lnd(I))       !mixing ratio 
               else
@@ -694,6 +696,7 @@ CONTAINS
               endif ! lsm
             ENDIF
             IF (icy(i)) THEN
+              TSK_ice(I) = 0.5 * (tsurf_ice(i)+tskin_ice(i))
               if( lsm == lsm_ruc) then
                 QSFCMR_ice(I)=QSFC_ice(I)/(1.-QSFC_ice(I))       !mixing ratio 
               else

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -742,7 +742,7 @@
   standard_name = longitude_in_degree
   long_name = longitude in degree east
   units = degree_east
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = in

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -729,6 +729,24 @@
   type = logical
   intent = in
   optional = F
+[xlat_d]
+  standard_name = latitude_in_degree
+  long_name = latitude in degree north
+  units = degree_north
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[xlon_d]
+  standard_name = longitude_in_degree
+  long_name = longitude in degree east
+  units = degree_east
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [zs]
   standard_name = depth_of_soil_layers
   long_name = depth of soil levels for land surface model


### PR DESCRIPTION
1. Fixed bugs in MYNN surface layer scheme in land/ice/water parts of the code
    to avoid using in computations "huge" numbers of qsfc_lnd, qsfc_ice and qsfc_wat.
2. Fixed bugs in MYNN surface layer scheme for initialization and consistent
    use of surface QV from RUC LSM over land and ice.
3. Passed into RUC LSM driver lat/lon for debug prints for a test point with known lat/lon.