### PR TITLE
Modified physics/drag_suite.F90 to remove topographic limitations on small-scale GWD and TOFD

### DIFF
--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -583,17 +583,20 @@ do i=1,im
    endif
 enddo
 
-do i=1,im
-   if ( dx(i) .ge. dxmax_ss ) then
-      ss_taper(i) = 1.
-   else
-      if ( dx(i) .le. dxmin_ss) then
-         ss_taper(i) = 0.
-      else
-         ss_taper(i) = dxmax_ss * (1. - dxmin_ss/dx(i))/(dxmax_ss-dxmin_ss)
-      endif
-   endif
-enddo
+! Temporary changes
+! do i=1,im
+!    if ( dx(i) .ge. dxmax_ss ) then
+!       ss_taper(i) = 1.
+!    else
+!       if ( dx(i) .le. dxmin_ss) then
+!          ss_taper(i) = 0.
+!       else
+!          ss_taper(i) = dxmax_ss * (1. - dxmin_ss/dx(i))/(dxmax_ss-dxmin_ss)
+!       endif
+!    endif
+! enddo
+! Temporary line
+ss_taper(:) = 1.
 
 !--- calculate length of grid for flow-blocking drag
 !
@@ -963,13 +966,15 @@ IF ( do_gsl_drag_ss ) THEN
          enddo
          if((xland(i)-1.5).le.0. .and. 2.*varss(i).le.hpbl(i))then
             if(br1(i).gt.0. .and. thvx(i,kpbl2)-thvx(i,kts) > 0.)then
-              cleff_ss    = sqrt(dxy(i)**2 + dxyp(i)**2)   ! WRF
+              ! Temporary changes denoted by "!!"
+              !! cleff_ss    = sqrt(dxy(i)**2 + dxyp(i)**2)   ! WRF
 !              cleff_ss    = 3. * max(dx(i),cleff_ss)
 !              cleff_ss    = 10. * max(dxmax_ss,cleff_ss)
-              cleff_ss    = 0.1 * max(dxmax_ss,cleff_ss)  ! WRF
+              !! cleff_ss    = 0.1 * max(dxmax_ss,cleff_ss)  ! WRF
 !               cleff_ss    = 0.1 * 12000.
-              coefm_ss(i) = (1. + olss(i)) ** (oass(i)+1.)
-              xlinv(i) = coefm_ss(i) / cleff_ss
+              !! coefm_ss(i) = (1. + olss(i)) ** (oass(i)+1.)
+              !!xlinv(i) = coefm_ss(i) / cleff_ss
+              xlinv(i) = 0.001*pi   ! 2km horizontal wavelength
               !govrth(i)=g/(0.5*(thvx(i,kpbl(i))+thvx(i,kts)))
               govrth(i)=g/(0.5*(thvx(i,kpbl2)+thvx(i,kts)))
               !XNBV=sqrt(govrth(i)*(thvx(i,kpbl(i))-thvx(i,kts))/hpbl(i))
@@ -980,8 +985,10 @@ IF ( do_gsl_drag_ss ) THEN
                 !tauwavex0=0.5*XNBV*xlinv(i)*(2*MIN(varss(i),75.))**2*ro(i,kts)*u1(i,kpbl(i))
                 !tauwavex0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*u1(i,kpbl2)
                 !tauwavex0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*u1(i,3)
-                var_temp = MIN(varss(i),varmax_ss) +                       &
-                              MAX(0.,beta_ss*(varss(i)-varmax_ss))
+                ! Temporary change
+                var_temp = varss(i)
+                !var_temp = MIN(varss(i),varmax_ss) +                       &
+                !              MAX(0.,beta_ss*(varss(i)-varmax_ss))
                 ! Note:  This is a semi-implicit treatment of the time differencing
                 var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
                 tauwavex0=var_temp2*u1(i,kvar)/(1.+var_temp2*deltim)
@@ -995,8 +1002,10 @@ IF ( do_gsl_drag_ss ) THEN
                 !tauwavey0=0.5*XNBV*xlinv(i)*(2*MIN(varss(i),75.))**2*ro(i,kts)*v1(i,kpbl(i))
                 !tauwavey0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*v1(i,kpbl2)
                 !tauwavey0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*v1(i,3)
-                var_temp = MIN(varss(i),varmax_ss) +                       &
-                              MAX(0.,beta_ss*(varss(i)-varmax_ss))
+                ! Temporary change
+                var_temp = varss(i)
+                ! var_temp = MIN(varss(i),varmax_ss) +                       &
+                !               MAX(0.,beta_ss*(varss(i)-varmax_ss))
                 ! Note:  This is a semi-implicit treatment of the time differencing
                 var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
                 tauwavey0=var_temp2*v1(i,kvar)/(1.+var_temp2*deltim)
@@ -1060,17 +1069,21 @@ IF ( do_gsl_drag_tofd ) THEN
 
          IF ((xland(i)-1.5) .le. 0.) then
             !(IH*kflt**n1)**-1 = (0.00102*0.00035**-1.9)**-1 = 0.00026615161
-            var_temp = MIN(varss(i),varmax_fd) +                           &
-                       MAX(0.,beta_fd*(varss(i)-varmax_fd))
-            var_temp = MIN(var_temp, 250.)
+            ! Temporary changes
+            var_temp = varss(i)
+            ! var_temp = MIN(varss(i),varmax_fd) +                           &
+            !            MAX(0.,beta_fd*(varss(i)-varmax_fd))
+            ! var_temp = MIN(var_temp, 250.)
             a1=0.00026615161*var_temp**2
 !           a1=0.00026615161*MIN(varss(i),varmax)**2
 !           a1=0.00026615161*(0.5*varss(i))**2
            ! k1**(n1-n2) = 0.003**(-1.9 - -2.8) = 0.003**0.9 = 0.005363
             a2=a1*0.005363
            ! Revise e-folding height based on PBL height and topographic std. dev. -- M. Toy 3/12/2018
-            H_efold = max(2*varss(i),hpbl(i))
-            H_efold = min(H_efold,1500.)
+            ! Temporary changes
+            !  H_efold = max(2*varss(i),hpbl(i))
+            !  H_efold = min(H_efold,1500.)
+            H_efold = 1500.
             DO k=kts,km
                wsp=SQRT(u1(i,k)**2 + v1(i,k)**2)
                ! alpha*beta*Cmd*Ccorr*2.109 = 12.*1.*0.005*0.6*2.109 = 0.0759


### PR DESCRIPTION
This is an enhancement to two GSL drag suite components:  1) Small-scale gravity wave drag, and 2) Turbulent orographic form drag (TOFD).  The limits to orographic variance was eliminated and the e-folding height of the TOFD scheme is returned to it's original height of 1.5km.  The results improved 10m windspeed verification in a May 2021 retro test as shown in the attached report (*.pdf).  The enhancements are shown by "Experiment 3" in the report.

Regression tests were performed to generate baseline files.  The tests passed on Hera (Intel and GNU compilers) and on Jet (Intel compiler).  The results are in the corresponding tests/RegressionsTests*log files.

The baseline files are on Hera at:
/scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL/
/scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_GNU/

And on Jet at:
/lfs4/BMC/wrfruc/mtoy/RT_BASELINE/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL/


[RRFS_GWD_retro_results_2021_12_03.pdf](https://github.com/NOAA-GSL/ccpp-physics/files/8219444/RRFS_GWD_retro_results_2021_12_03.pdf)

