### PR TITLE
Bug fixes to drag_suite.F90 and GFS_surface_composites.F90

### DIFF
--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -222,6 +222,7 @@ contains
         endif
         if (dry(i)) then                   ! Land
           uustar_lnd(i) = uustar(i)
+          if(lsm /= lsm_ruc) weasd_lnd(i) = weasd(i)
            tsurf_lnd(i) = tsfcl(i)
         ! DH*
         else
@@ -232,6 +233,7 @@ contains
         endif
         if (icy(i)) then                   ! Ice
           uustar_ice(i) = uustar(i)
+          if(lsm /= lsm_ruc) weasd_ice(i) = weasd(i)
            tsurf_ice(i) = tisfc(i)
             ep1d_ice(i) = zero
             gflx_ice(i) = zero
@@ -259,7 +261,6 @@ contains
         endif
       enddo
 !
-     if(lsm /= lsm_ruc) then ! do not do snow initialization  with RUC lsm
       if (frac_grid) then
         do i=1,im
           if (dry(i)) then
@@ -281,6 +282,7 @@ contains
           endif
         enddo
       else
+       if(lsm /= lsm_ruc) then ! do not do snow initialization  with RUC lsm
         do i=1,im
           !-- print ice point
           !if ( (xlon_d(i) > 298.6) .and.  (xlon_d(i) < 298.7) .and. &
@@ -301,8 +303,8 @@ contains
             endif
           endif
         enddo
+       endif ! lsm/=lsm_ruc
       endif
-     endif ! lsm/=lsm_ruc
 
 !     write(0,*)' minmax of ice snow=',minval(snowd_ice),maxval(snowd_ice)
 

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -589,19 +589,7 @@ do i=1,im
    endif
 enddo
 
-! Temporary changes
-! do i=1,im
-!    if ( dx(i) .ge. dxmax_ss ) then
-!       ss_taper(i) = 1.
-!    else
-!       if ( dx(i) .le. dxmin_ss) then
-!          ss_taper(i) = 0.
-!       else
-!          ss_taper(i) = dxmax_ss * (1. - dxmin_ss/dx(i))/(dxmax_ss-dxmin_ss)
-!       endif
-!    endif
-! enddo
-! Temporary line
+! Remove ss_tapering
 ss_taper(:) = 1.
 
 ! SPP, if spp_gwd is 0, no perturbations are applied.
@@ -989,14 +977,10 @@ IF ( do_gsl_drag_ss ) THEN
          enddo
          if((xland(i)-1.5).le.0. .and. 2.*varss_stoch(i).le.hpbl(i))then
             if(br1(i).gt.0. .and. thvx(i,kpbl2)-thvx(i,kts) > 0.)then
-              ! Temporary changes denoted by "!!"
-              !! cleff_ss    = sqrt(dxy(i)**2 + dxyp(i)**2)   ! WRF
+              ! Modify xlinv to represent wave number of "typical" small-scale topography 
 !              cleff_ss    = 3. * max(dx(i),cleff_ss)
 !              cleff_ss    = 10. * max(dxmax_ss,cleff_ss)
-              !! cleff_ss    = 0.1 * max(dxmax_ss,cleff_ss)  ! WRF
 !               cleff_ss    = 0.1 * 12000.
-              !! coefm_ss(i) = (1. + olss(i)) ** (oass(i)+1.)
-              !!xlinv(i) = coefm_ss(i) / cleff_ss
               xlinv(i) = 0.001*pi   ! 2km horizontal wavelength
               !govrth(i)=g/(0.5*(thvx(i,kpbl(i))+thvx(i,kts)))
               govrth(i)=g/(0.5*(thvx(i,kpbl2)+thvx(i,kts)))
@@ -1008,10 +992,8 @@ IF ( do_gsl_drag_ss ) THEN
                 !tauwavex0=0.5*XNBV*xlinv(i)*(2*MIN(varss(i),75.))**2*ro(i,kts)*u1(i,kpbl(i))
                 !tauwavex0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*u1(i,kpbl2)
                 !tauwavex0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*u1(i,3)
-                ! Temporary change
-                var_temp = varss(i)
-                !var_temp = MIN(varss_stoch(i),varmax_ss_stoch(i)) +                       &
-                !              MAX(0.,beta_ss*(varss_stoch(i)-varmax_ss_stoch(i)))
+                ! Remove limit on varss_stoch
+                var_temp = varss_stoch(i)
                 ! Note:  This is a semi-implicit treatment of the time differencing
                 var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
                 tauwavex0=var_temp2*u1(i,kvar)/(1.+var_temp2*deltim)
@@ -1025,10 +1007,8 @@ IF ( do_gsl_drag_ss ) THEN
                 !tauwavey0=0.5*XNBV*xlinv(i)*(2*MIN(varss(i),75.))**2*ro(i,kts)*v1(i,kpbl(i))
                 !tauwavey0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*v1(i,kpbl2)
                 !tauwavey0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*v1(i,3)
-                ! Temporary change
-                var_temp = varss(i)
-                !var_temp = MIN(varss_stoch(i),varmax_ss_stoch(i)) +                       &
-                !              MAX(0.,beta_ss*(varss_stoch(i)-varmax_ss_stoch(i)))
+                ! Remove limit on varss_stoch
+                var_temp = varss_stoch(i)
                 ! Note:  This is a semi-implicit treatment of the time differencing
                 var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
                 tauwavey0=var_temp2*v1(i,kvar)/(1.+var_temp2*deltim)
@@ -1092,20 +1072,15 @@ IF ( do_gsl_drag_tofd ) THEN
 
          IF ((xland(i)-1.5) .le. 0.) then
             !(IH*kflt**n1)**-1 = (0.00102*0.00035**-1.9)**-1 = 0.00026615161
-            ! Temporary changes
-            var_temp = varss(i)
-            !var_temp = MIN(varss_stoch(i),varmax_fd_stoch(i)) +                           &
-            !           MAX(0.,beta_fd*(varss_stoch(i)-varmax_fd_stoch(i)))
+            ! Remove limit on varss_stoch
+            var_temp = varss_stoch(i)
             !var_temp = MIN(var_temp, 250.)
             a1=0.00026615161*var_temp**2
 !           a1=0.00026615161*MIN(varss(i),varmax)**2
 !           a1=0.00026615161*(0.5*varss(i))**2
            ! k1**(n1-n2) = 0.003**(-1.9 - -2.8) = 0.003**0.9 = 0.005363
             a2=a1*0.005363
-           ! Revise e-folding height based on PBL height and topographic std. dev. -- M. Toy 3/12/2018
-            ! Temporary changes
-            !H_efold = max(2*varss_stoch(i),hpbl(i))
-            !H_efold = min(H_efold,1500.)
+            ! Beljaars H_efold
             H_efold = 1500.
             DO k=kts,km
                wsp=SQRT(u1(i,k)**2 + v1(i,k)**2)


### PR DESCRIPTION
Fixed bug in drag_suite.F90 that prevented stochastic physics from functioning for small-scale GWD and turbulent orographic form drag.  Also, deleted commented-out lines from previous commit.

Fixed bugs in GFS_surface_composites.F90 (bug fixes by @tanyasmirnova ).

## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  Hera:  Intel and GNU.  Jet: Intel.
Are the changes covered by regression tests? Yes. 
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? Yes.
- Please commit the regression test log files in your ufs-weather-model branch

Baseline Reg test data on Hera at:
/scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL.2022_03_19
and
/scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_GNU.2022_03_19

Baseline Reg test data on Jet at:
/lfs4/BMC/wrfruc/mtoy/RT_BASELINE/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL.2022_03_19

