### PR TITLE
GWD, LSM and MYNN physics updates from RRFS_dev branch

### DIFF
--- a/physics/GFS_surface_composites.meta
+++ b/physics/GFS_surface_composites.meta
@@ -14,6 +14,22 @@
   dimensions = ()
   type = integer
   intent = in
+[xlat_d]
+  standard_name = latitude_in_degree
+  long_name = latitude in degree north
+  units = degree_north
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[xlon_d]
+  standard_name = longitude_in_degree
+  long_name = longitude in degree east
+  units = degree_east
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
 [flag_init]
   standard_name = flag_for_first_timestep
   long_name = flag signaling first time step for time integration loop
@@ -21,9 +37,9 @@
   dimensions = ()
   type = logical
   intent = in
-[flag_restart]
-  standard_name = flag_for_restart
-  long_name = flag for restart (warmstart) or coldstart
+[lsm_cold_start]
+  standard_name = do_lsm_cold_start
+  long_name = flag to signify LSM is cold-started
   units = flag
   dimensions = ()
   type = logical
@@ -69,6 +85,20 @@
   units = flag
   dimensions = ()
   type = logical
+  intent = in
+[lsm]
+  standard_name = control_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[lsm_ruc]
+  standard_name = identifier_for_ruc_land_surface_scheme
+  long_name = flag for RUC land surface model
+  units = flag
+  dimensions = ()
+  type = integer
   intent = in
 [landfrac]
   standard_name = land_area_fraction

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -589,17 +589,8 @@ do i=1,im
    endif
 enddo
 
-do i=1,im
-   if ( dx(i) .ge. dxmax_ss ) then
-      ss_taper(i) = 1.
-   else
-      if ( dx(i) .le. dxmin_ss) then
-         ss_taper(i) = 0.
-      else
-         ss_taper(i) = dxmax_ss * (1. - dxmin_ss/dx(i))/(dxmax_ss-dxmin_ss)
-      endif
-   endif
-enddo
+! Remove ss_tapering
+ss_taper(:) = 1.
 
 ! SPP, if spp_gwd is 0, no perturbations are applied.
 if ( spp_gwd==1 ) then
@@ -986,13 +977,11 @@ IF ( do_gsl_drag_ss ) THEN
          enddo
          if((xland(i)-1.5).le.0. .and. 2.*varss_stoch(i).le.hpbl(i))then
             if(br1(i).gt.0. .and. thvx(i,kpbl2)-thvx(i,kts) > 0.)then
-              cleff_ss    = sqrt(dxy(i)**2 + dxyp(i)**2)   ! WRF
+              ! Modify xlinv to represent wave number of "typical" small-scale topography 
 !              cleff_ss    = 3. * max(dx(i),cleff_ss)
 !              cleff_ss    = 10. * max(dxmax_ss,cleff_ss)
-              cleff_ss    = 0.1 * max(dxmax_ss,cleff_ss)  ! WRF
 !               cleff_ss    = 0.1 * 12000.
-              coefm_ss(i) = (1. + olss(i)) ** (oass(i)+1.)
-              xlinv(i) = coefm_ss(i) / cleff_ss
+              xlinv(i) = 0.001*pi   ! 2km horizontal wavelength
               !govrth(i)=g/(0.5*(thvx(i,kpbl(i))+thvx(i,kts)))
               govrth(i)=g/(0.5*(thvx(i,kpbl2)+thvx(i,kts)))
               !XNBV=sqrt(govrth(i)*(thvx(i,kpbl(i))-thvx(i,kts))/hpbl(i))
@@ -1003,8 +992,8 @@ IF ( do_gsl_drag_ss ) THEN
                 !tauwavex0=0.5*XNBV*xlinv(i)*(2*MIN(varss(i),75.))**2*ro(i,kts)*u1(i,kpbl(i))
                 !tauwavex0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*u1(i,kpbl2)
                 !tauwavex0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*u1(i,3)
-                var_temp = MIN(varss_stoch(i),varmax_ss_stoch(i)) +                       &
-                              MAX(0.,beta_ss*(varss_stoch(i)-varmax_ss_stoch(i)))
+                ! Remove limit on varss_stoch
+                var_temp = varss_stoch(i)
                 ! Note:  This is a semi-implicit treatment of the time differencing
                 var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
                 tauwavex0=var_temp2*u1(i,kvar)/(1.+var_temp2*deltim)
@@ -1018,8 +1007,8 @@ IF ( do_gsl_drag_ss ) THEN
                 !tauwavey0=0.5*XNBV*xlinv(i)*(2*MIN(varss(i),75.))**2*ro(i,kts)*v1(i,kpbl(i))
                 !tauwavey0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*v1(i,kpbl2)
                 !tauwavey0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*v1(i,3)
-                var_temp = MIN(varss_stoch(i),varmax_ss_stoch(i)) +                       &
-                              MAX(0.,beta_ss*(varss_stoch(i)-varmax_ss_stoch(i)))
+                ! Remove limit on varss_stoch
+                var_temp = varss_stoch(i)
                 ! Note:  This is a semi-implicit treatment of the time differencing
                 var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
                 tauwavey0=var_temp2*v1(i,kvar)/(1.+var_temp2*deltim)
@@ -1083,17 +1072,16 @@ IF ( do_gsl_drag_tofd ) THEN
 
          IF ((xland(i)-1.5) .le. 0.) then
             !(IH*kflt**n1)**-1 = (0.00102*0.00035**-1.9)**-1 = 0.00026615161
-            var_temp = MIN(varss_stoch(i),varmax_fd_stoch(i)) +                           &
-                       MAX(0.,beta_fd*(varss_stoch(i)-varmax_fd_stoch(i)))
-            var_temp = MIN(var_temp, 250.)
+            ! Remove limit on varss_stoch
+            var_temp = varss_stoch(i)
+            !var_temp = MIN(var_temp, 250.)
             a1=0.00026615161*var_temp**2
 !           a1=0.00026615161*MIN(varss(i),varmax)**2
 !           a1=0.00026615161*(0.5*varss(i))**2
            ! k1**(n1-n2) = 0.003**(-1.9 - -2.8) = 0.003**0.9 = 0.005363
             a2=a1*0.005363
-           ! Revise e-folding height based on PBL height and topographic std. dev. -- M. Toy 3/12/2018
-            H_efold = max(2*varss_stoch(i),hpbl(i))
-            H_efold = min(H_efold,1500.)
+            ! Beljaars H_efold
+            H_efold = 1500.
             DO k=kts,km
                wsp=SQRT(u1(i,k)**2 + v1(i,k)**2)
                ! alpha*beta*Cmd*Ccorr*2.109 = 12.*1.*0.005*0.6*2.109 = 0.0759

--- a/physics/module_sf_mynn.F90
+++ b/physics/module_sf_mynn.F90
@@ -112,7 +112,7 @@ MODULE module_sf_mynn
                                         !1: check input
                                         !2: everything - heavy I/O
   LOGICAL, PARAMETER :: compute_diag = .false.
-  LOGICAL, PARAMETER :: compute_flux = .false.  !shouldn't need compute 
+  LOGICAL, PARAMETER :: compute_flux = .true.  !shouldn't need compute 
                ! these in FV3. They will be written over anyway.
                ! Computing the fluxes here is leftover from the WRF world.
 

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -2595,7 +2595,8 @@ endif
 ! 3feb21 - in RRFS testing (fv3-based), ref*0.5 gives too much direct
 !          evaporation. Therefore , it is replaced with ref*0.7.
         !fc=max(qmin,ref*0.5)
-        fc=max(qmin,ref*0.7)
+        !fc=max(qmin,ref*0.7)
+        fc=ref
         fex_fc=1.
       if((soilmois(1)+qmin) > fc .or. (qvatm-qvg) > 0.) then
         soilres = 1.


### PR DESCRIPTION
Description:

This PR updates CCPP physics modules for the gravity wave drag (GWD), LSM and MYNN surface layer parameterization.  These updates are from the RRFS_dev branch.

1)  GWD — drag_suite.F90:  Removed limits on standard deviation of small-scale topography used by the small-scale GWD and turbulent orographic form drag (TOFD) schemes of the GSL drag suite.  Removed the height limitation of the TOFD scheme.

2)  LSM:

    There are a few changes in GFS_surface_composites.F90
    1. Added lat/lon to the parameter list for debugging purposes.
    2. Flag_restart is replaced with lsm_cold_start - no impact on the result.
    3. Removed snow initialization with the use of RUC LSM. In case of a cold
    start, snow on land or on ice is initialized in io/FV3GFS_io.F90. In case of
    a warm start, these variables are carried along.
    3. Corresponding changes in GFS_surface_composites.meta.

For module_sf_ruclsm.F90
   1. In computation of soil resistance to evaporation use soil moisture field capacity with factor 1. instead of 0.7. 
      This change will reduce direct evaporation from the bare soil.

3)  MYNN sfc_layer — module_sf_mynn.F90:  changed "compute_flux" logical parameter from .false. to .true.



This PR changes the results, so baseline results were created by the Regression Tests.

The following RT's passed:
Hera - Intel — baseline results at:  /scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL.2022_03_25
Hera - GNU — baseline results at:  /scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_GNU.2022_03_25
Jet — Intel — baseline results at: /lfs4/BMC/wrfruc/mtoy/RT_BASELINE/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL.2022_03_25 
