### PR TITLE
merging MYNN mods from gsl/develop

### DIFF
--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -744,21 +744,7 @@
             enddo
           endif
         elseif (imp_physics == imp_physics_gfdl) then            ! GFDL MP
-          if ((imfdeepcnv==imfdeepcnv_gf .or. do_mynnedmf) .and. kdt>1) then
-            if (do_mynnedmf) then
-              do k=1,lm
-                k1 = k + kd
-                do i=1,im
-                  if (tracer1(i,k1,ntrw)>1.0e-7 .OR. tracer1(i,k1,ntsw)>1.0e-7) then
-                  ! GFDL cloud fraction
-                    cldcov(i,k1) = tracer1(i,k1,ntclamt)
-                  else
-                  ! MYNN sub-grid cloud fraction
-                    cldcov(i,k1) = clouds1(i,k1)
-                  endif
-                enddo
-              enddo
-            else ! imfdeepcnv==imfdeepcnv_gf
+          if ((imfdeepcnv==imfdeepcnv_gf) .and. kdt>1) then
               do k=1,lm
                 k1 = k + kd
                 do i=1,im
@@ -770,7 +756,6 @@
                 endif
                 enddo
               enddo
-            endif
           else
             ! GFDL cloud fraction
             cldcov(1:IM,1+kd:LM+kd) = tracer1(1:IM,1:LM,ntclamt)

--- a/physics/GFS_rrtmgp_gfdlmp_pre.F90
+++ b/physics/GFS_rrtmgp_gfdlmp_pre.F90
@@ -165,16 +165,9 @@ contains
        where(cld_reice .gt. radice_upr) cld_reice = radice_upr
     endif
     
-    ! Cloud-fraction. For mynnedmf, cld_frac is adjusted for precipitation here, otherwise
-    ! it passes through this interface. It is adjusted prior in sgscloudradpre. 
+    ! Cloud-fraction. For mynnedmf, cld_frac is already defined in sgscloudradpre. 
     if (do_mynnedmf .and. kdt .gt. 1) then
-       do iLay = 1, nLev
-          do iCol = 1, nCol
-             if (tracer(iCol,iLay,i_cldrain) > 1.0e-7 .OR. tracer(iCol,iLay,i_cldsnow)>1.0e-7) then
-                cld_frac(iCol,iLay) = tracer(iCol,iLay,i_cldtot)
-             endif
-          enddo
-       enddo
+       !already set in sgscloudradpre
     else
        cld_frac(1:nCol,1:nLev) = tracer(1:nCol,1:nLev,i_cldtot)
     endif

--- a/physics/module_MYNNPBL_wrapper.meta
+++ b/physics/module_MYNNPBL_wrapper.meta
@@ -764,6 +764,14 @@
   type = real
   kind = kind_phys
   intent = inout
+[Sm3D]
+  standard_name = stability_function_for_momentum
+  long_name = stability function for momentum
+  units = none
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
 [exch_h]
   standard_name = atmosphere_heat_diffusivity_for_mynnpbl
   long_name = diffusivity for heat for MYNN PBL (defined for all mass levels)


### PR DESCRIPTION
[](https://user-images.githubusercontent.com/14096622/159797131-6b8d6afa-52e4-46fc-a16d-fa422efde9aa.png)[](https://user-images.githubusercontent.com/14096622/159904184-5db9a7ee-b7fa-45f5-9f0e-f188d91461dd.png)Updates/fixes:

1. removed the first-order for of Chaboureau-Bechtold (CB) - now only uses q'2 version of CB
2. changed CB to use abs temperature instead of liquid temperature
3. Added 3d variable "sm3d" - stability function for momentum
4. revert to Tian-Kuang lateral entrainment - reduces high RH bias found in some HRRR cases
5. reduced entrainment rate for momentum

For more details, please visit the PR made to ccpp/physics on 22 March 2022:
https://github.com/NOAA-GSL/ccpp-physics/pull/141
