### PR TITLE
Adds @middlecoff as a codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @SamuelTrahanNOAA @tanyasmirnova @christinaholtNOAA @joeolson42 @hannahcbarnes @mdtoyNOAA @haiqinli @zhanglikate 
+*       @SamuelTrahanNOAA @tanyasmirnova @christinaholtNOAA @joeolson42 @hannahcbarnes @mdtoyNOAA @haiqinli @zhanglikate @middlecoff
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
Adds @middlecoff as a codeowner in ccpp/physics for the RRFS_dev branch. This PR is for training purposes, and will have a new baseline and run the full suite of regression tests. It is not expected to change the results though.

Resolves #152