### PR TITLE
bugfix for converting abs temp to theta

### DIFF
--- a/physics/module_sf_mynn.F90
+++ b/physics/module_sf_mynn.F90
@@ -848,7 +848,7 @@ CONTAINS
 
       DO I=its,ite
          ! CONVERT LOWEST LAYER TEMPERATURE TO POTENTIAL TEMPERATURE:     
-         TH1D(I)=T1D(I)**(100000./P1D(I))**ROVCP !(Theta, K)
+         TH1D(I)=T1D(I)*(100000./P1D(I))**ROVCP  !(Theta, K)
          TC1D(I)=T1D(I)-273.15                   !(T, Celsius)
       ENDDO
 


### PR DESCRIPTION
Emergency bugfix for the MYNN surface layer scheme:

 TH1D(I)=T1D(I)**(100000./P1D(I))**ROVCP !(Theta, K)

The first "**" should be a single "*"

