### PR TITLE
- Updates GF and sgscloud_radpre for HFIP

### DIFF
--- a/physics/cu_gf_deep.F90
+++ b/physics/cu_gf_deep.F90
@@ -353,13 +353,13 @@ contains
      integer                              ::                             &
        iloop,nens3,ki,kk,i,k
      real(kind=kind_phys)                 ::                             &
-      dz,dzo,mbdt,radius,pefc,                                           &
+      dz,dzo,mbdt,radius,                                                &
       zcutdown,depth_min,zkbmax,z_detr,zktop,                            &
       dh,cap_maxs,trash,trash2,frh,sig_thresh
      real(kind=kind_phys) entdo,dp,subin,detdo,entup,                    &
       detup,subdown,entdoj,entupk,detupk,totmas
 
-     real(kind=kind_phys), dimension (its:ite) :: lambau,flux_tun,zws,ztexec,zqexec
+     real(kind=kind_phys), dimension (its:ite) :: lambau,flux_tun,zws,ztexec,zqexec,pefc
 !$acc declare create(lambau,flux_tun,zws,ztexec,zqexec)
 
      integer :: jprnt,jmini,start_k22

--- a/physics/cu_gf_deep.F90
+++ b/physics/cu_gf_deep.F90
@@ -353,13 +353,14 @@ contains
      integer                              ::                             &
        iloop,nens3,ki,kk,i,k
      real(kind=kind_phys)                 ::                             &
-      dz,dzo,mbdt,radius,pefc,                                           &
+      dz,dzo,mbdt,radius,                                                &
       zcutdown,depth_min,zkbmax,z_detr,zktop,                            &
       dh,cap_maxs,trash,trash2,frh,sig_thresh
      real(kind=kind_phys) entdo,dp,subin,detdo,entup,                    &
       detup,subdown,entdoj,entupk,detupk,totmas
 
-     real(kind=kind_phys), dimension (its:ite) :: lambau,flux_tun,zws,ztexec,zqexec,pefc
+     real(kind=kind_phys), dimension (its:ite) :: lambau,flux_tun,zws,ztexec,zqexec
+     real(kind=kind_phys), dimension (its:ite) :: pefc
 !$acc declare create(lambau,flux_tun,zws,ztexec,zqexec)
 
      integer :: jprnt,jmini,start_k22

--- a/physics/cu_gf_driver.meta
+++ b/physics/cu_gf_driver.meta
@@ -322,6 +322,14 @@
   type = real
   kind = kind_phys
   intent = in
+[aerodp]
+  standard_name = atmosphere_optical_thickness_due_to_ambient_aerosol_particles
+  long_name = vertical integrated optical depth for various aerosol species
+  units = none
+  dimensions = (horizontal_loop_extent,number_of_species_for_aerosol_optical_depth)
+  type = real
+  kind = kind_phys
+  intent = in
 [aod_gf]
   standard_name = aerosol_optical_depth_for_grell_freitas_deep_convection
   long_name = aerosol optical depth used in Grell-Freitas Convective Parameterization

--- a/physics/cu_gf_sh.F90
+++ b/physics/cu_gf_sh.F90
@@ -55,7 +55,6 @@ contains
 !!\param    cupclw             incloud mixing ratio of cloudwater/ice (for radiation)
 !!                            this needs heavy tuning factors, since cloud fraction is
 !!                             not included (kg/kg)
-!!\param    cnvwt              required for gfs physics
 !!\param    itf,ktf,its,ite, kts,kte are dimensions
 !!\param    ipr               horizontal index of printed column
 !!\param    tropics            =0
@@ -65,7 +64,7 @@ contains
                          us,vs,zo,t,q,z1,tn,qo,po,psur,dhdt,kpbl,rho,     & ! input variables, must be supplied
                          hfx,qfx,xland,ichoice,tcrit,dtime,         &
                          zuo,xmb_out,kbcon,ktop,k22,ierr,ierrc,     &
-                         outt,outq,outqc,outu,outv,cnvwt,pre,cupclw,     & ! output tendencies
+                         outt,outq,outqc,outu,outv,pre,cupclw,      & ! output tendencies
                          itf,ktf,its,ite, kts,kte,ipr,tropics)  ! dimesnional variables
 !
 ! this module needs some subroutines from gf_deep
@@ -90,8 +89,8 @@ contains
   ! pre    = output precip
      real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
         ,intent (inout  )                 ::                           &
-        cnvwt,outt,outq,outqc,cupclw,zuo,outu,outv
-!$acc declare copy(cnvwt,outt,outq,outqc,cupclw,zuo,outu,outv)
+        outt,outq,outqc,cupclw,zuo,outu,outv
+!$acc declare copy(outt,outq,outqc,cupclw,zuo,outu,outv)
      real(kind=kind_phys),    dimension (its:ite)                                      &
         ,intent (out  )                   ::                           &
         xmb_out
@@ -665,7 +664,6 @@ contains
 !$acc loop independent
          do k=k22(i)+1,ktop(i)
           dp=100.*(po_cup(i,k)-po_cup(i,k+1))
-          cnvwt(i,k)=zuo(i,k)*cupclw(i,k)*g/dp
 !$acc atomic
           trash2=trash2+entr_rate_2d(i,k)
 !$acc atomic

--- a/physics/sgscloud_radpre.F90
+++ b/physics/sgscloud_radpre.F90
@@ -289,10 +289,10 @@
 
                 !Partition the convective clouds into water & frozen species
                 liqfrac = min(1., max(0., (Tk-244.)/29.))
-                qc(i,k) = qc(i,k)+qci_conv(i,k)*liqfrac
+                !qc(i,k) = qc(i,k)+qci_conv(i,k)*liqfrac
                 !split ice & snow 50-50%
-                qi(i,k) = qi(i,k)+0.5*qci_conv(i,k)*(1. - liqfrac)
-                qs(i,k) = qs(i,k)+0.5*qci_conv(i,k)*(1. - liqfrac)
+                !qi(i,k) = qi(i,k)+0.5*qci_conv(i,k)*(1. - liqfrac)
+                !qs(i,k) = qs(i,k)+0.5*qci_conv(i,k)*(1. - liqfrac)
 
                 !eff radius cloud water (microns)
                 if (nint(slmsk(i)) == 1) then !land


### PR DESCRIPTION
- GF Changes:
```
- Merra2 AOD read into GF, replaces assumed globally uniform AOD. This change is more realistic. 
- Removes edtmax and edtmin
- Removes double counting in sgscloud_radpre when GF is used
- Output updraft mass flux and precipitation includes the all elements of the tri-modal precipitation desciption (small, mid, and deep can co-exist in one grid point)
- Mass factor included in pwav, pwev, and pwavh. 
- psum, psumh is removed since that variable is the same as pwav, pwavh
- Assumed precipitation efficiency is increased
- Temperature and specific humidity input into is now updated by the previous parameterizations
- -z_detr increased to 1000
```