### PR TITLE
RUC LSM precision workaround

### DIFF
--- a/physics/lsm_ruc.F90
+++ b/physics/lsm_ruc.F90
@@ -1115,6 +1115,20 @@ module lsm_ruc
         z0_lnd(i,j)  = z0rl_lnd(i)/100.
         znt_lnd(i,j) = z0rl_lnd(i)/100.
 
+        ! Workaround needed for subnormal numbers.  This should be
+        ! done after all other sanity checks, in case a sanity check
+        ! results in subnormal numbers.
+        !
+        ! This bug was caught by the UFS gfortran debug-mode
+        ! regression tests, and the fix is necessary to pass those
+        ! tests.
+        if(abs(snowh_lnd(i,j))<1e-20) then
+          snowh_lnd(i,j)=0
+        endif
+        if(abs(sneqv_lnd(i,j))<1e-20) then
+          sneqv_lnd(i,j)=0
+        endif
+
         !if (debug_print) then
         !-- diagnostics for a land test point with known lat/lon
         if (kdt < 10) then
@@ -1416,6 +1430,19 @@ module lsm_ruc
 
         z0_ice(i,j)  = z0rl_ice(i)/100.
         znt_ice(i,j) = z0rl_ice(i)/100.
+
+        ! Workaround needed for subnormal numbers.  This should be
+        ! done after all other sanity checks, in case a sanity check
+        ! results in subnormal numbers.
+        !
+        ! Although this bug has not been triggered yet, it is expected
+        ! to be, like the _lnd variants many lines up from here.
+        if(abs(snowh_ice(i,j))<1e-20) then
+          snowh_ice(i,j)=0
+        endif
+        if(abs(sneqv_ice(i,j))<1e-20) then
+          sneqv_ice(i,j)=0
+        endif
 
 !> - Call RUC LSM lsmruc() for ice.
       call lsmruc(xlat_d(i),xlon_d(i),                                       &

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -584,15 +584,6 @@ CONTAINS
 
       DO i=its,ite
 
-         IF(ABS(SNOWH(I,J))<1e-20) THEN
-           ! Workaround needed for subnormal numbers (gfortran issue)
-           SNOWH(I,J)=0
-         ENDIF
-         IF(ABS(SNOW(I,J))<1e-20) THEN
-           ! Workaround needed for subnormal numbers (gfortran issue)
-           SNOW(I,J)=0
-         ENDIF
-
     IF (debug_print ) THEN
        if (abs(xlat-testptlat).lt.0.2 .and.                         &
            abs(xlon-testptlon).lt.0.2)then

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -584,6 +584,15 @@ CONTAINS
 
       DO i=its,ite
 
+         IF(ABS(SNOWH(I,J))<1e-20) THEN
+           ! Workaround needed for subnormal numbers (gfortran issue)
+           SNOWH(I,J)=0
+         ENDIF
+         IF(ABS(SNOW(I,J))<1e-20) THEN
+           ! Workaround needed for subnormal numbers (gfortran issue)
+           SNOW(I,J)=0
+         ENDIF
+
     IF (debug_print ) THEN
        if (abs(xlat-testptlat).lt.0.2 .and.                         &
            abs(xlon-testptlon).lt.0.2)then


### PR DESCRIPTION
The module_sf_ruclsm has comparisons to zero, which break the code when numbers are very close to 0, such as 1e-322. This happens with the gfortran compiler when compled -DDEBUG=ON since the option to truncate subnormal numbers is turned off.

My fix is truncate subnormal numbers manually, for the two variables that cause trouble.

Another possible fix is to remove all comparisons to zero and all equality comparisons from the ruclsm. However, I don't know why the developer used that method of comparing, nor what the appropriate epsilons are for the comparisons. Ultimately, this would require changing many more lines of code than my approach.

This is a copy of the community PR, with a different destination (RRFS_dev)

https://github.com/ufs-community/ccpp-physics/pull/6