### PR TITLE
update smoke emission reading and direct feedback

### DIFF
--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -19,7 +19,7 @@
       subroutine GFS_rrtmg_pre_run (im, levs, lm, lmk, lmp, n_var_lndp,        &
         imfdeepcnv, imfdeepcnv_gf, me, ncnd, ntrac, num_p3d, npdf3d, ncnvcld3d,&
         ntqv, ntcw,ntiw, ntlnc, ntinc, ntrnc, ntsnc, ntccn,                    &
-        ntrw, ntsw, ntgl, nthl, ntwa, ntoz,                                    &
+        ntrw, ntsw, ntgl, nthl, ntwa, ntoz, ntsmoke, ntdust,                   &
         ntclamt, nleffr, nieffr, nseffr, lndp_type, kdt,                       &
         imp_physics,imp_physics_nssl, nssl_ccn_on, nssl_invertccn,             &
         imp_physics_thompson, imp_physics_gfdl, imp_physics_zhao_carr,         &
@@ -88,6 +88,7 @@
                                            ntcw, ntiw, ntlnc, ntinc,           &
                                            ntrnc, ntsnc,ntccn,                 &
                                            ntrw, ntsw, ntgl, nthl, ntwa, ntoz, &
+                                           ntsmoke, ntdust,                    &
                                            ntclamt, nleffr, nieffr, nseffr,    &
                                            lndp_type,                          &
                                            kdt, imp_physics,                   &
@@ -136,7 +137,8 @@
                                                           cnvw_in, cnvc_in,    &
                                                           sppt_wts
 
-      real(kind=kind_phys), dimension(:,:,:), intent(in) :: qgrs, aer_nm
+      real(kind=kind_phys), dimension(:,:,:), intent(in) :: qgrs
+      real(kind=kind_phys), dimension(:,:,:), intent(inout) :: aer_nm
 
       real(kind=kind_phys), dimension(:),   intent(inout) :: coszen, coszdg
 
@@ -601,6 +603,19 @@
 !! property profile for radiation.
 
 !check  print *,' in grrad : calling setaer '
+
+!>---   add smoke and dust ---
+       if (aero_dir_fdb) then
+         do k=1,lmk
+           do i=1,im
+             aer_nm(i,k,1 )=aer_nm(i,k,1 )+qgrs(i,k,ntdust )*0.11
+             aer_nm(i,k,2 )=aer_nm(i,k,1 )+qgrs(i,k,ntdust )*0.89
+             aer_nm(i,k,12)=aer_nm(i,k,12)+qgrs(i,k,ntsmoke)*0.01
+             aer_nm(i,k,14)=aer_nm(i,k,14)+qgrs(i,k,ntsmoke)*0.99
+            enddo
+          enddo
+       endif
+!>----------------------------
 
       call setaer (plvl, plyr, prslk1, tvly, rhly, slmsk,    & !  ---  inputs
                    tracer1, aer_nm, xlon, xlat, IM, LMK, LMP,&

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -205,6 +205,20 @@
   dimensions = ()
   type = integer
   intent = in
+[ntsmoke]
+  standard_name = index_for_smoke_in_tracer_concentration_array
+  long_name = tracer index for smoke
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+[ntdust]
+  standard_name = index_for_dust_in_tracer_concentration_array
+  long_name = tracer index for dust
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
 [nssl_ccn_on]
   standard_name = nssl_ccn_on
   long_name = CCN activation flag in NSSL micro
@@ -719,7 +733,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_aerosol_tracers_MG)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dx]
   standard_name = characteristic_grid_lengthscale
   long_name = relative dx for the grid cell

--- a/physics/smoke/rrfs_smoke_wrapper.F90
+++ b/physics/smoke/rrfs_smoke_wrapper.F90
@@ -380,7 +380,7 @@ contains
     hwp = 0.
     do i=its,ite
       wdgust(i)=max(1.68*sqrt(us3d(i,1)**2+vs3d(i,1)**2),3.)
-      snoweq(i)=max((25.-snow(i)*1000.)/25.,0.)
+      snoweq(i)=max((25.-snow(i))/25.,0.)
       hwp(i)=0.237*wdgust(i)**1.11*max(t2m(i)-dpt2m(i),15.)**0.92*((1.-wetness(i))**6.95)*snoweq(i) ! Eric 08/2022
     enddo
     

--- a/physics/smoke/rrfs_smoke_wrapper.F90
+++ b/physics/smoke/rrfs_smoke_wrapper.F90
@@ -691,12 +691,12 @@ contains
       emis_anoc(i) = emi_in(i,1)
     enddo
 
-    if (hour_int<=24) then
+    if (hour_int<24) then
         do j=jts,jte
          do i=its,ite
-          ebb_smoke_hr(i)  = smoke_RRFS(i,int(gmt)+1,1) ! smoke
-          frp_hr      (i)  = smoke_RRFS(i,int(gmt)+1,2) ! frp
-          frp_std_hr  (i)  = smoke_RRFS(i,int(gmt)+1,3) ! std frp
+          ebb_smoke_hr(i)  = smoke_RRFS(i,hour_int+1,1) ! smoke
+          frp_hr      (i)  = smoke_RRFS(i,hour_int+1,2) ! frp
+          frp_std_hr  (i)  = smoke_RRFS(i,hour_int+1,3) ! std frp
           ebu_in    (i,j)  = ebb_smoke_hr(i)
           plume_frp(i,j,p_frp_hr     ) = conv_frp* frp_hr  (i)
           plume_frp(i,j,p_frp_std    ) = conv_frp* frp_std_hr  (i)

--- a/physics/smoke/rrfs_smoke_wrapper.meta
+++ b/physics/smoke/rrfs_smoke_wrapper.meta
@@ -263,9 +263,9 @@
   kind = kind_phys
   intent = in
 [snow]
-  standard_name = lwe_thickness_of_snow_amount
-  long_name = snow fall on physics timestep
-  units = m
+  standard_name = lwe_surface_snow
+  long_name = water equivalent snow depth
+  units = mm
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys


### PR DESCRIPTION
1. Update the smoke emission reading to be consistent with the latest regional workflow, which does smoke preprocessing in each cycle;
2. Add the smoke and dust direct feedback, which is off by default.
3. The regression test was successful on Hera with INTEL compiler.